### PR TITLE
Add wiki links to all features

### DIFF
--- a/src/_data/features.js
+++ b/src/_data/features.js
@@ -2,270 +2,323 @@ export default [
   {
     image: '/img/features/attackstyles.png',
     title: 'Attack style',
-    description: 'Indicates your attack style and hides unwanted styles.'
+    description: 'Indicates your attack style and hides unwanted styles.',
+    link: 'https://github.com/runelite/runelite/wiki/Attack-Styles'
   },
   {
     image: '/img/features/grounditems.png',
     title: 'Ground items',
-    description: 'Hides, highlights, and adds filterable price colors to dropped items.'
+    description: 'Hides, highlights, and adds filterable price colors to dropped items.',
+    link: 'https://github.com/runelite/runelite/wiki/Ground-Items'
   },
   {
     image: '/img/features/boosts.png',
     title: 'Status widgets',
     description: 'Shows boost timers, enemy HP, and other useful overlays.',
+    link: 'https://github.com/runelite/runelite/wiki/Status-Widgets',
     home: true
   },
   {
     image: '/img/features/mousehighlight.png',
     title: 'Action tooltips',
-    description: 'Displays tooltips for actions under your mouse cursor.'
+    description: 'Displays tooltips for actions under your mouse cursor.',
+    link: 'https://github.com/runelite/runelite/wiki/Mouse-Tooltips'
   },
   {
     image: '/img/features/hunter.png',
     title: 'Hunter',
-    description: 'Adds timers to hunter traps.'
+    description: 'Adds timers to hunter traps.',
+    link: 'https://github.com/runelite/runelite/wiki/Hunter'
   },
   {
     image: '/img/features/runepouch.png',
     title: 'Rune pouch',
-    description: 'Shows what runes are currently in your rune pouch.'
+    description: 'Shows what runes are currently in your rune pouch.',
+    link: 'https://github.com/runelite/runelite/wiki/Rune-Pouch'
   },
   {
     image: '/img/features/cluescroll.png',
     title: 'Clue scroll helper',
-    description: 'Gives answers to clue scroll riddles/anagrams/ciphers/cryptic clues.'
+    description: 'Gives answers to clue scroll riddles/anagrams/ciphers/cryptic clues.',
+    link: 'https://github.com/runelite/runelite/wiki/Clue-Scrolls'
   },
   {
     image: '/img/features/imp.png',
     title: 'Impling finder',
-    description: 'Highlights nearby implings on the minimap and on-screen.'
+    description: 'Highlights nearby implings on the minimap and on-screen.',
+    link: 'https://github.com/runelite/runelite/wiki/Implings'
   },
   {
     image: '/img/features/playerindicators.png',
     title: 'Player indicators',
-    description: 'Draws the names of friends, clan mates and yourself overhead.'
+    description: 'Draws the names of friends, clan mates and yourself overhead.',
+    link: 'https://github.com/runelite/runelite/wiki/Player-Indicators'
   },
   {
     image: '/img/features/fishing.png',
     title: 'Fishing',
-    description: 'Highlights fishing spots and tracks fishing stats.'
+    description: 'Highlights fishing spots and tracks fishing stats.',
+    link: 'https://github.com/runelite/runelite/wiki/Fishing'
   },
   {
     image: '/img/features/globes.png',
     title: 'XP globes',
-    description: 'Displays skill globes when you gain XP, with more detailed stats on hover.'
+    description: 'Displays skill globes when you gain XP, with more detailed stats on hover.',
+    link: 'https://github.com/runelite/runelite/wiki/XP-Globes'
   },
   {
     image: '/img/features/idle.png',
     title: 'Idle notifications',
-    description: 'Sends system tray alerts when idle or about to be logged out.'
+    description: 'Sends system tray alerts when idle or about to be logged out.',
+    link: 'https://github.com/runelite/runelite/wiki/Idle-Notifier'
   },
   {
     image: '/img/features/teamcape.png',
     title: 'Team cape overlay',
-    description: 'Displays team cape wearer counts.'
+    description: 'Displays team cape wearer counts.',
+    link: 'https://github.com/runelite/runelite/wiki/Team-Capes'
   },
   {
     image: '/img/features/abyss.png',
     title: 'Runecraft',
-    description: 'Displays minimap icons and clickboxes for abyssal rifts.'
+    description: 'Displays minimap icons and clickboxes for abyssal rifts.',
+    link: 'https://github.com/runelite/runelite/wiki/Runecraft'
   },
   {
     image: '/img/features/agility.png',
     title: 'Agility',
-    description: 'Displays clickboxes for agility courses, and counts the number of laps you have done.'
+    description: 'Displays clickboxes for agility courses, and counts the number of laps you have done.',
+    link: 'https://github.com/runelite/runelite/wiki/Agility'
   },
   {
     image: '/img/features/barbassault.png',
     title: 'Barbarian Assault',
-    description: 'Displays a timer for the next change of horn commands.'
+    description: 'Displays a timer for the next change of horn commands.',
+    link: 'https://github.com/runelite/runelite/wiki/Barbarian-Assault'
   },
   {
     image: '/img/features/cannon.png',
     title: 'Dwarf multicannon',
-    description: 'Displays the number of cannonballs left in your cannon, along with common cannon spots.'
+    description: 'Displays the number of cannonballs left in your cannon, along with common cannon spots.',
+    link: 'https://github.com/runelite/runelite/wiki/Cannon'
   },
   {
     image: '/img/features/chatcommands.png',
     title: 'Chat commands',
-    description: 'Allows easy lookup of !level(s) and !price(s) from the chat box.'
+    description: 'Allows easy lookup of !level(s) and !price(s) from the chat box.',
+    link: 'https://github.com/runelite/runelite/wiki/Chat-Commands'
   },
   {
     image: '/img/features/clanchat.png',
     title: 'Clan chat',
-    description: 'Adds the sender\'s rank to clan chat messages.'
+    description: 'Adds the sender\'s rank to clan chat messages.',
+    link: 'https://github.com/runelite/runelite/wiki/Clan-Chat'
   },
   {
     image: '/img/features/discord.png',
     title: 'Discord integration',
     description: 'Integrates with Discord\'s Rich Presence to display what you\'re doing in the game.',
+    link: 'https://github.com/runelite/runelite/wiki/Discord',
     home: true
   },
   {
     image: '/img/features/itemstats.png',
     title: 'Item stats',
-    description: 'Displays information about food and potion effects.'
+    description: 'Displays information about food and potion effects.',
+    link: 'https://github.com/runelite/runelite/wiki/Item-Stats'
   },
   {
     image: '/img/features/jewellerycount.png',
     title: 'Jewellery charges',
-    description: 'Displays the number of charges that your jewellery has.'
+    description: 'Displays the number of charges that your jewellery has.',
+    link: 'https://github.com/runelite/runelite/wiki/Jewellery-Count'
   },
   {
     image: '/img/features/lowdetail.png',
     title: 'Low detail mode',
-    description: 'Enables low detail mode, removing some of the game\'s eye candy.'
+    description: 'Enables low detail mode, removing some of the game\'s eye candy.',
+    link: 'https://github.com/runelite/runelite/wiki/Low-Detail'
   },
   {
     image: '/img/features/mlm.png',
     title: 'Motherlode Mine',
-    description: 'Marks veins and rock obstacles in the Motherlode Mine.'
+    description: 'Marks veins and rock obstacles in the Motherlode Mine.',
+    link: 'https://github.com/runelite/runelite/wiki/Motherload-Mine'
   },
   {
     image: '/img/features/poh.png',
     title: 'Player-owned houses',
-    description: 'Displays minimap icons and marks unlit/lit burners.'
+    description: 'Displays minimap icons and marks unlit/lit burners.',
+    link: 'https://github.com/runelite/runelite/wiki/Player-owned-House'
   },
   {
     image: '/img/features/tileindicators.png',
     title: 'Tile indicator',
-    description: 'Marks the tile you last clicked on.'
+    description: 'Marks the tile you last clicked on.',
+    link: 'https://github.com/runelite/runelite/wiki/Tile-Indicators'
   },
   {
     image: '/img/features/wcing.png',
     title: 'Woodcutting',
-    description: 'Displays information about the logs you are cutting.'
+    description: 'Displays information about the logs you are cutting.',
+    link: 'https://github.com/runelite/runelite/wiki/Woodcutting'
   },
   {
     image: '/img/features/zoom.png',
     title: 'Zoom unlimiter',
-    description: 'Allows you to zoom past the default camera distance limits.'
+    description: 'Allows you to zoom past the default camera distance limits.',
+    link: 'https://github.com/runelite/runelite/wiki/Camera-Zoom'
   },
   {
     image: '/img/features/barrows.png',
     title: 'Barrows',
-    description: 'Displays minimap information for the tunnel and marks the location of brothers.'
+    description: 'Displays minimap information for the tunnel and marks the location of brothers.',
+    link: 'https://github.com/runelite/runelite/wiki/Barrows-Brothers'
   },
   {
     image: '/img/features/nmz.png',
     title: 'Nightmare Zone',
-    description: 'Displays NMZ points/absorption and notifies you about expiring potions.'
+    description: 'Displays NMZ points/absorption and notifies you about expiring potions.',
+    link: 'https://github.com/runelite/runelite/wiki/Nightmare-Zone'
   },
   {
     image: '/img/features/puzzlebox.png',
     title: 'Puzzle box solver',
     description: 'Shows you where to click to solve puzzle boxes.',
+    link: 'https://github.com/runelite/runelite/wiki/Puzzle-Solver',
     home: true
   },
   {
     image: '/img/features/roguesden.png',
     title: 'Rogues\' Den',
-    description: 'Marks tiles and clickboxes to help you traverse the maze.'
+    description: 'Marks tiles and clickboxes to help you traverse the maze.',
+    link: 'https://github.com/runelite/runelite/wiki/Rogues%27-Den'
   },
   {
     image: '/img/features/raids.png',
     title: 'Raid scouter',
-    description: 'Displays the current layout of raids and tracks the raid duration.'
+    description: 'Displays the current layout of raids and tracks the raid duration.',
+    link: 'https://github.com/runelite/runelite/wiki/Chambers-of-Xeric'
   },
   {
     image: '/img/features/blastfurnace.png',
     title: 'Blast Furnace',
-    description: 'Shows your current bars/ores and marks the clickbox of the conveyor belt.'
+    description: 'Shows your current bars/ores and marks the clickbox of the conveyor belt.',
+    link: 'https://github.com/runelite/runelite/wiki/Blast-Furnace'
   },
   {
     image: '/img/features/minimapdots.png',
     title: 'Minimap dot customizer',
-    description: 'Customizes the color of minimap dots.'
+    description: 'Customizes the color of minimap dots.',
+    link: 'https://github.com/runelite/runelite/wiki/Minimap'
   },
   {
     image: '/img/features/kourend.png',
     title: 'Arceuus Library',
-    description: 'Shows you where books are in the Arceuus Library.'
+    description: 'Shows you where books are in the Arceuus Library.',
+    link: 'https://github.com/runelite/runelite/wiki/Kourend-Library'
   },
   {
     image: '/img/features/ge.png',
     title: 'Grand Exchange offers',
-    description: 'Lists your current Grand Exchange offers.'
+    description: 'Lists your current Grand Exchange offers.',
+    link: 'https://github.com/runelite/runelite/wiki/Grand-Exchange'
   },
   {
     image: '/img/features/cannontiles.png',
     title: 'Cannon double hit spots',
-    description: 'Shows you where to position enemies for double cannonball hits.'
+    description: 'Shows you where to position enemies for double cannonball hits.',
+    link: 'https://github.com/runelite/runelite/wiki/Cannon'
   },
   {
     image: '/img/features/gesearch.png',
     title: 'Grand Exchange lookup',
-    description: 'Quickly price-check any item on the Grand Exchange.'
+    description: 'Quickly price-check any item on the Grand Exchange.',
+    link: 'https://github.com/runelite/runelite/wiki/Grand-Exchange'
   },
   {
     image: '/img/features/newsfeed.png',
     title: 'News feed',
-    description: 'Displays the latest RuneLite blog posts, OldSchool RuneScape news, and a Twitter feed of JMods.'
+    description: 'Displays the latest RuneLite blog posts, OldSchool RuneScape news, and a Twitter feed of JMods.',
+    link: 'https://github.com/runelite/runelite/wiki/News-Feed'
   },
   {
     image: '/img/features/stretchedfixed.png',
     title: 'Stretched fixed mode',
-    description: 'Stretches the game to the size of your window while in fixed mode.'
+    description: 'Stretches the game to the size of your window while in fixed mode.',
+    link: 'https://github.com/runelite/runelite/wiki/Stretched-Fixed-Mode'
   },
   {
     image: '/img/features/regen.png',
     title: 'Regen timers',
-    description: 'Tracks and displays the hitpoints & special attack regen timers.'
+    description: 'Tracks and displays the hitpoints & special attack regen timers.',
+    link: 'https://github.com/runelite/runelite/wiki/Regeneration-Meter'
   },
   {
     image: '/img/features/menuswap.png',
     title: 'Menu entry swapping',
-    description: 'Swaps the left-click actions of certain objects.'
+    description: 'Swaps the left-click actions of certain objects.',
+    link: 'https://github.com/runelite/runelite/wiki/Menu-Entry-Swapper'
   },
   {
     image: '/img/features/bankeval.png',
     title: 'Bank evaluator',
-    description: 'Displays your bank\'s total value based on GE and alch prices.'
+    description: 'Displays your bank\'s total value based on GE and alch prices.',
+    link: 'https://github.com/runelite/runelite/wiki/Bank-Value'
   },
   {
     image: '/img/features/npctag.png',
     title: 'NPC tagging',
-    description: 'Tags and keeps track of an NPC.'
+    description: 'Tags and keeps track of an NPC.',
+    link: 'https://github.com/runelite/runelite/wiki/NPC-Indicators'
   },
   {
     image: '/img/features/herbiboar.png',
     title: 'Herbiboar',
-    description: 'Highlights the path and objects to search at the end of the trail.'
+    description: 'Highlights the path and objects to search at the end of the trail.',
+    link: 'https://github.com/runelite/runelite/wiki/Herbiboar'
   },
   {
     image: '/img/features/prayerorder.png',
     title: 'Prayer reordering',
-    description: 'Allows you to drag-and-drop prayers in your prayer book.'
+    description: 'Allows you to drag-and-drop prayers in your prayer book.',
+    link: 'https://github.com/runelite/runelite/wiki/Reorder-Prayers'
   },
   {
     image: '/img/features/tithefarm.png',
     title: 'Tithe Farm',
-    description: 'Displays timers for the farming patches within the Tithe farm minigame.'
+    description: 'Displays timers for the farming patches within the Tithe farm minigame.',
+    link: 'https://github.com/runelite/runelite/wiki/Tithe-Farm'
   },
   {
     image: '/img/features/moveableoverlay.png',
     title: 'Custom overlay position',
-    description: 'Allows you to move RuneLite overlays to any position on the screen.'
+    description: 'Allows you to move RuneLite overlays to any position on the screen.',
+    link: 'https://github.com/runelite/runelite/wiki/Status-Widgets'
   },
   {
     image: '/img/features/daily.png',
     title: 'Daily task indicators',
-    description: 'Notifies you on login what daily tasks you are able to complete.'
+    description: 'Notifies you on login what daily tasks you are able to complete.',
+    link: 'https://github.com/runelite/runelite/wiki/Daily-Task-Indicator'
   },
   {
     image: '/img/features/favor.png',
     title: 'Miscellania favor',
-    description: 'Displays your current favor and treasury in the Kingdom of Miscellania.'
+    description: 'Displays your current favor and treasury in the Kingdom of Miscellania.',
+    link: 'https://github.com/runelite/runelite/wiki/Kingdom-of-Miscellania'
   },
   {
     image: '/img/features/shiftclick.png',
     title: 'Shift click configuration',
-    description: 'Allows you to change/set shift click actions on items.'
+    description: 'Allows you to change/set shift click actions on items.',
+    link: 'https://github.com/runelite/runelite/wiki/Shift-Click-Configuration'
   },
   {
     image: '/img/features/banktags.png',
     title: 'Bank tags',
     description: 'Allows you to set searchable tags on items for your bank.',
+    link: 'https://github.com/runelite/runelite/wiki/Bank-Tags',
     home: true
   }
 ]

--- a/src/components/feature.js
+++ b/src/components/feature.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { Col, Card, CardImg, CardText, CardBody, CardTitle } from 'reactstrap'
 
-const Feature = ({ image, title, description }) => (
+const Feature = ({ image, title, description, link }) => (
   <Col xl='3' lg='3' md='4' sm='6' xs='12' style={{ marginBottom: 15 }}>
     <Card>
       <CardImg top src={image} />
       <CardBody>
-        <CardTitle>{title}</CardTitle>
+        <CardTitle><a href={link}>{title}</a></CardTitle>
         <CardText>{description}</CardText>
       </CardBody>
     </Card>


### PR DESCRIPTION
There was a similar PR for the RuneLite itself, so I thought of adding it to the website as well so people can find more information about plugins and discover the wiki.

If I should add any checks (like if the link key doesn't exist, which just adds a <a>Title</a> right now) or add a target=_blank, I can try to do that.