### PR TITLE
Xptracker: remove curve from the line graphs

### DIFF
--- a/src/containers/xp/show.js
+++ b/src/containers/xp/show.js
@@ -25,6 +25,14 @@ Chart.defaults.options = {
   }
 }
 
+const straightLineGraphOption = {
+  elements: {
+    line: {
+      tension: 0
+    }
+  }
+}
+
 const reverseGraphOptions = {
   scales: {
     yAxes: [{
@@ -32,7 +40,8 @@ const reverseGraphOptions = {
         reverse: true
       }
     }]
-  }
+  },
+  ...straightLineGraphOption
 }
 
 const capitalizeFirstLetter = (string) => string.charAt(0).toUpperCase() + string.slice(1)
@@ -70,7 +79,7 @@ const XpShow = ({ children, start, end, name, skill, ranks, skillRank, skillXp, 
         </Col>
         <Col md='9' sm='8' xs='12'>
           <Line data={skillRank} options={reverseGraphOptions} />
-          <Line data={skillXp} />
+          <Line data={skillXp} options={straightLineGraphOption} />
           <Bar data={allXp} />
           <Bar data={allRanks} />
         </Col>


### PR DESCRIPTION
Remove the curve from the following line graphs:
* Skill rank
* Experience gained

Before(Curve):
![curve](https://user-images.githubusercontent.com/36420562/41656885-bf8ef4e0-7491-11e8-9354-f0d50842e186.PNG)

After(Straight):
![straight](https://user-images.githubusercontent.com/36420562/41656899-c9c9f16c-7491-11e8-9ee7-512abbe32801.PNG)

Fixes #56 