### PR TITLE
Support for Internet Explorer 11

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
     <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#0d0b0a">
     <meta name="theme-color" content="#ffffff">
+	<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.includes"></script>
     <!--
     small hack to allow us having full screen images/backgrounds etc
     -->

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -70,7 +70,7 @@ class Hero extends React.Component {
     const jumboBottom = jumbo.offsetTop + jumbo.offsetHeight
     const navbar = document.getElementsByClassName('navbar')[0]
     const fromTop = jumboBottom - navbar.offsetHeight
-    const stop = document.documentElement.scrollTop
+    const stop = window.scrollY || window.pageYOffset || document.body.scrollTop
 
     if (stop > fromTop) {
       Hero.makeNavigationWhite()

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -56,13 +56,13 @@ class Hero extends React.Component {
   static makeNavigationDark () {
     const navbar = Hero.getNavbar()
     navbar.className = navbar.className.replace('navbar-light', 'navbar-dark').replace('bg-white', 'bg-faded')
-    navbar.style = 'background: linear-gradient(rgba(0,0,0,0.7) 40%, transparent)'
+    navbar.style.background = 'linear-gradient(rgba(0,0,0,0.7) 40%, transparent)'
   }
 
   static makeNavigationWhite () {
     const navbar = Hero.getNavbar()
     navbar.className = navbar.className.replace('navbar-dark', 'navbar-light').replace('bg-faded', 'bg-white')
-    navbar.style = ''
+    navbar.style.background = ''
   }
 
   static handleScroll () {

--- a/src/redux/modules/runelite.js
+++ b/src/redux/modules/runelite.js
@@ -144,7 +144,7 @@ export const getXpRange = createAction(getSessionCountRoutine.TRIGGER, ({skill, 
 const capitalizeFirstLetter = (string) => string.charAt(0).toUpperCase() + string.slice(1)
 const skillNames = Object.keys(skills)
 const capitalizedSkills = Object.keys(skills).map(skill => capitalizeFirstLetter(skill))
-const skillColors = Object.values(skills)
+const skillColors = Object.keys(skills).map(key => skills[key])
 const calculateOverallXp = (xpEntry) => skillNames.map(skill => xpEntry[skill + '_xp'] || 0).reduce((a, b) => a + b, 0)
 
 const calculateRanksAndExp = (collector) => (value, key) => {


### PR DESCRIPTION
We do have a couple of users that try to use the site on IE11 and they end up downloading the all platforms jar and opening it in notepad. This makes the site's render work as it does on other browsers, on IE11. The `Object.values` patch is included because without it, opening the devtools crashes IE.

Fixes #75 