### PR TITLE
Replace moment.js with day.js, make chart.js continuosly update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3171,6 +3171,12 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.7.5.tgz",
+      "integrity": "sha512-OzkAcosqOgWgQF+dQTXO/iaSGa3hMs/sSkfzkxwWpZXqJEbaA0V6O1V+Ew2tGBlTz1r7Rb7opU3w8ympWb9d2Q==",
+      "dev": true
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/fontawesome-free": "^5.3.1",
     "bootstrap": "^4.1.3",
     "chart.js": "^2.7.2",
-    "moment": "^2.22.2",
+    "dayjs": "^1.7.5",
     "platform": "^1.3.5",
     "preact": "^8.3.1",
     "preact-redux": "^2.0.3",

--- a/src/modules/runelite.js
+++ b/src/modules/runelite.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import dayjs from 'dayjs'
 import { uniq, concat, forEachObjIndexed } from 'ramda'
 import { createAction, handleActions } from 'redux-actions'
 import { createRoutine } from 'redux-routines'
@@ -95,9 +95,9 @@ export const getXpRange = createAction(
     const xp = []
 
     for (
-      let momDate = moment(start);
-      momDate.diff(end) <= 0;
-      momDate.add(1, 'days')
+      let momDate = dayjs(start);
+      momDate.diff(end, 'day') <= 0;
+      momDate = momDate.add(1, 'day')
     ) {
       const date = momDate.toDate()
       const dateString = date.toISOString()

--- a/src/routes/xp-show.js
+++ b/src/routes/xp-show.js
@@ -14,7 +14,7 @@ import hero from '../_data/hero'
 import Meta from '../components/meta'
 import { bindActionCreators } from 'redux'
 import { Link } from 'preact-router'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import Chart from 'chart.js'
 
 Chart.defaults.global.animation = false
@@ -51,7 +51,7 @@ function parseDate (date, from) {
     date = new Date()
   } else if (!isNumeric(date)) {
     const parsed = date.match(/(\d+)(\w+)/)
-    date = moment(from)
+    date = dayjs(from)
       .subtract(parsed[1], parsed[2])
       .toDate()
   } else {


### PR DESCRIPTION
- Instead of using huge moment.js use day.js what is mostly max ~2kb in size (compared to almost 20kb of moment.js)
- The total bundle size is mostly not changed, the moment.js dependency was moved to xp-tracker chunk because chart.js is already using moment. This will reduce the overhead everywhere else except XP tracker page
- Make chart.js continuously update its data instead of fully recreating entire chart every property change