### PR TITLE
Simplify redux modules

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -65,6 +65,10 @@ module.exports = function override (config, env) {
   config = rewirePreact(config, env)
   config = rewireEslint(config, env)
 
+  if (process.env.NODE_ENV !== 'production') {
+    return config
+  }
+
   const posts = fs.readdirSync(path.join('src', '_posts'))
   const routes = ['/', '/features', '/blog'].concat(
     posts.map(fileName => '/blog/show/' + parseBlog(fileName).id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,9 +3525,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.63",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.63.tgz",
-      "integrity": "sha512-Ec35NNY040HKuSxMAzBMgz/uUI78amSWpBUD9x2gN7R7gkb/wgAcClngWklcLP0/lm/g0UUYHnC/tUIlZj8UvQ==",
+      "version": "1.3.64",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.64.tgz",
+      "integrity": "sha512-CU5ta5MbzRre+WhzKfPBM3HlyZGM7bwNKmiByzFzCfxP3q7cNmGLKopq5Q+LGXza69aIHXk2sZZSh/Oh7TKPIQ==",
       "dev": true
     },
     "elliptic": {
@@ -11720,14 +11720,6 @@
       "dev": true,
       "requires": {
         "deep-diff": "^0.3.5"
-      }
-    },
-    "redux-routines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redux-routines/-/redux-routines-3.0.0.tgz",
-      "integrity": "sha512-PwRBcNM5PEX5Kye749WwBNtmEXDCdMHJvFxy/9QzlVaWX+alfSfJgYzFGA0OZT7RxUriusEKhgALWCUVpPZ0Cg==",
-      "requires": {
-        "redux-actions": "^2.3.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "ramda": "^0.25.0",
     "redux": "^4.0.0",
     "redux-actions": "^2.6.1",
-    "redux-routines": "^3.0.0",
     "reselect": "^3.0.1",
     "s-ago": "^1.3.0"
   },

--- a/src/modules/app.js
+++ b/src/modules/app.js
@@ -1,13 +1,17 @@
-import { createAction, handleActions } from 'redux-actions'
+import { createActions, handleActions } from 'redux-actions'
 
-// Reducer
+export const { startLoading, stopLoading } = createActions(
+  'START_LOADING',
+  'STOP_LOADING'
+)
+
 export default handleActions(
   {
-    START_LOADING: state => ({
+    [startLoading]: state => ({
       ...state,
       loading: true
     }),
-    STOP_LOADING: state => ({
+    [stopLoading]: state => ({
       ...state,
       loading: false
     })
@@ -16,6 +20,3 @@ export default handleActions(
     loading: false
   }
 )
-
-export const startLoading = createAction('START_LOADING')
-export const stopLoading = createAction('STOP_LOADING')

--- a/src/modules/git.js
+++ b/src/modules/git.js
@@ -1,5 +1,4 @@
-import { createAction, handleActions } from 'redux-actions'
-import { createRoutine } from 'redux-routines'
+import { createActions, handleActions } from 'redux-actions'
 import { createSelector } from 'reselect'
 import git from '../_data/git'
 import api from '../api'
@@ -8,24 +7,65 @@ import { startLoading, stopLoading } from './app'
 const githubApi = api('https://api.github.com/')
 
 // Actions
-export const getCommitsRoutine = createRoutine('react-ui/git/GET_COMMITS')
-export const getReleasesRoutine = createRoutine('react-ui/git/GET_RELEASES')
-export const getRepositoryRoutine = createRoutine(
-  'react-ui/git/GET_REPOSITORY'
+export const {
+  getCommits,
+  getReleases,
+  getRepository,
+  setCommits,
+  setReleases,
+  setRepository
+} = createActions(
+  {
+    GET_COMMITS: () => async dispatch => {
+      dispatch(startLoading())
+      const response = await githubApi(
+        `repos/${git.user}/${git.repository}/commits`,
+        { method: 'GET' }
+      )
+
+      dispatch(setCommits(response))
+      dispatch(stopLoading())
+      return response
+    },
+    GET_REPOSITORY: () => async dispatch => {
+      dispatch(startLoading())
+      const response = await githubApi(`repos/${git.user}/${git.repository}`, {
+        method: 'GET'
+      })
+
+      dispatch(setRepository(response))
+      dispatch(stopLoading())
+      return response
+    },
+    GET_RELEASES: () => async dispatch => {
+      dispatch(startLoading())
+      const response = await githubApi(
+        `repos/${git.user}/${git.repository}/tags`,
+        { method: 'GET' }
+      )
+
+      dispatch(setReleases(response))
+      dispatch(stopLoading())
+      return response
+    }
+  },
+  'SET_COMMITS',
+  'SET_RELEASES',
+  'SET_REPOSITORY'
 )
 
 // Reducer
 export default handleActions(
   {
-    [getCommitsRoutine.SUCCESS]: (state, { payload }) => ({
+    [setCommits]: (state, { payload }) => ({
       ...state,
       commits: payload
     }),
-    [getReleasesRoutine.SUCCESS]: (state, { payload }) => ({
+    [setReleases]: (state, { payload }) => ({
       ...state,
       releases: payload
     }),
-    [getRepositoryRoutine.SUCCESS]: (state, { payload }) => ({
+    [setRepository]: (state, { payload }) => ({
       ...state,
       repository: payload
     })
@@ -34,51 +74,6 @@ export default handleActions(
     commits: [],
     releases: [],
     repository: {}
-  }
-)
-
-// Action creators
-export const getCommits = createAction(
-  getCommitsRoutine.TRIGGER,
-  () => async dispatch => {
-    dispatch(startLoading())
-    const response = await githubApi(
-      `repos/${git.user}/${git.repository}/commits`,
-      { method: 'GET' }
-    )
-
-    dispatch(getCommitsRoutine.success(response))
-    dispatch(stopLoading())
-    return response
-  }
-)
-
-export const getReleases = createAction(
-  getReleasesRoutine.TRIGGER,
-  () => async dispatch => {
-    dispatch(startLoading())
-    const response = await githubApi(
-      `repos/${git.user}/${git.repository}/tags`,
-      { method: 'GET' }
-    )
-
-    dispatch(getReleasesRoutine.success(response))
-    dispatch(stopLoading())
-    return response
-  }
-)
-
-export const getRepository = createAction(
-  getRepositoryRoutine.TRIGGER,
-  () => async dispatch => {
-    dispatch(startLoading())
-    const response = await githubApi(`repos/${git.user}/${git.repository}`, {
-      method: 'GET'
-    })
-
-    dispatch(getRepositoryRoutine.success(response))
-    dispatch(stopLoading())
-    return response
   }
 )
 

--- a/src/modules/navigation.js
+++ b/src/modules/navigation.js
@@ -1,8 +1,10 @@
-import { createAction, handleActions } from 'redux-actions'
+import { createActions, handleActions } from 'redux-actions'
+
+export const { changeStyle } = createActions('CHANGE_STYLE')
 
 export default handleActions(
   {
-    CHANGE_STYLE: (state, { payload }) => ({
+    [changeStyle]: (state, { payload }) => ({
       ...state,
       dark: payload
     })
@@ -11,5 +13,3 @@ export default handleActions(
     dark: false
   }
 )
-
-export const changeStyle = createAction('CHANGE_STYLE', dark => dark)

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -24,9 +24,8 @@ import Async from '../components/async'
 class Home extends Component {
   componentDidMount () {
     this.props.getCommits()
-    this.props.getReleases()
+    this.props.getReleases().then(() => this.props.getSessionCount())
     this.props.getRepository()
-    this.props.getSessionCount()
   }
 
   render ({ commit, release, stars, sessionCount }) {

--- a/src/routes/xp-show.js
+++ b/src/routes/xp-show.js
@@ -9,6 +9,7 @@ import Chartist from 'chartist'
 import 'chartist-plugin-tooltips'
 import './xp-show.css'
 import Layout from '../components/layout'
+import { getReleases } from '../modules/git'
 import {
   allRanksSelector,
   allXpSelector,
@@ -146,12 +147,14 @@ class XpShow extends Component {
       allXp: new Chartist.Bar('#all-xp', {}, options).on('draw', skillColor)
     })
 
-    this.props.getXpRange({
-      skill: this.props.skill,
-      name: this.props.name,
-      start: startDate,
-      end: endDate
-    })
+    this.props.getReleases().then(() =>
+      this.props.getXpRange({
+        skill: this.props.skill,
+        name: this.props.name,
+        start: startDate,
+        end: endDate
+      })
+    )
   }
 
   componentWillReceiveProps ({ skillRank, skillXp, allRanks, allXp }) {
@@ -238,5 +241,5 @@ export default connect(
     allRanks: allRanksSelector(state, props),
     allXp: allXpSelector(state, props)
   }),
-  dispatch => bindActionCreators({ getXpRange }, dispatch)
+  dispatch => bindActionCreators({ getReleases, getXpRange }, dispatch)
 )(XpShow)


### PR DESCRIPTION
- Switch from redux-routine to simply dispatching end actions
- Use createActions instead of createAction per-action and use .toString
on actions to handle them in reducers
- Fix prerendering being run in dev mode

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>