### PR TITLE
Fix links for homepage features

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -50,12 +50,9 @@ class Home extends Component {
           </h1>
           <hr />
           <div class="row">
-            {features
-              .filter(feature => feature.home)
-              .map(({ image, title }) => ({ image, title }))
-              .map(feature => (
-                <Feature key={feature.title} {...feature} />
-              ))}
+            {features.filter(feature => feature.home).map(feature => (
+              <Feature key={feature.title} {...feature} />
+            ))}
           </div>
           <h1 id="news">
             Latest news{' '}


### PR DESCRIPTION
Do not remove the URL part from feature data object when building the
feature components on home page.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>