### PR TITLE
Add /tag/show/:csv for showing tag tab

### DIFF
--- a/src/components/app.css
+++ b/src/components/app.css
@@ -10,6 +10,8 @@ pre {
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .dropdown:hover .dropdown-menu {

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -37,6 +37,10 @@ const App = ({ loading, stars, navbarDark }) => (
         path="/logged-in"
         getComponent={() => import('../routes/logged-in')}
       />
+      <Async
+        path="/tag/show/:csv"
+        getComponent={() => import('../routes/tag-show')}
+      />
       <Async default getComponent={() => import('../routes/not-found')} />
     </Router>
   </div>

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -37,6 +37,7 @@ const App = ({ loading, stars, navbarDark }) => (
         path="/logged-in"
         getComponent={() => import('../routes/logged-in')}
       />
+      <Async path="/tag" getComponent={() => import('../routes/tag')} />
       <Async
         path="/tag/show/:csv"
         getComponent={() => import('../routes/tag-show')}

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -55,9 +55,9 @@ const Navigation = ({ stars, dark }) => (
           </div>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/tag">
+          <Link class="nav-link" activeClassName="active" href="/tag">
             <i class="fas fa-code" /> Tags
-          </a>
+          </Link>
         </li>
         <li class="nav-item">
           <a class="nav-link" href={links.discord}>

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -55,6 +55,11 @@ const Navigation = ({ stars, dark }) => (
           </div>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="/tag">
+            <i class="fas fa-code" /> Tags
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href={links.discord}>
             <i class="fab fa-discord" /> Discord
           </a>

--- a/src/components/tooltip.css
+++ b/src/components/tooltip.css
@@ -1,0 +1,24 @@
+/* Tooltip text */
+.tooltip-tag .tooltip-tag-text {
+  padding: 5px;
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 0px;
+  line-height: normal;
+  font-size: smaller;
+
+  /* Position the tooltip text - see examples below! */
+  bottom: 100%;
+  left: 50%;
+  margin-left: -60px; /* Use half of the width (120/2 = 60), to center the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip-tag:hover .tooltip-tag-text {
+  visibility: visible;
+}

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,10 +1,12 @@
 import appReducer from './app'
 import gitReducer from './git'
 import runeliteReducer from './runelite'
+import tagReducer from './tag'
 
 // Combine all redux reducers into one root reducer
 export default {
   app: appReducer,
   git: gitReducer,
-  runelite: runeliteReducer
+  runelite: runeliteReducer,
+  tag: tagReducer
 }

--- a/src/modules/runelite.js
+++ b/src/modules/runelite.js
@@ -17,7 +17,6 @@ export const {
   setSessionCount,
   setXp,
   setXpRange,
-  setItems,
   setItemInfo
 } = createActions(
   {
@@ -82,7 +81,6 @@ export const {
     },
     GET_ITEM_INFO: items => async (dispatch, getState) => {
       dispatch(startLoading())
-      dispatch(setItems())
 
       const version = latestReleaseSelector(getState()).name
 
@@ -116,7 +114,6 @@ export const {
   'SET_SESSION_COUNT',
   'SET_XP',
   'SET_XP_RANGE',
-  'SET_ITEMS',
   'SET_ITEM_INFO'
 )
 
@@ -134,10 +131,6 @@ export default handleActions(
     [setXpRange]: (state, { payload }) => ({
       ...state,
       ...payload
-    }),
-    [setItems]: state => ({
-      ...state,
-      items: []
     }),
     [setItemInfo]: (state, { payload }) => ({
       ...state,

--- a/src/modules/runelite.js
+++ b/src/modules/runelite.js
@@ -95,7 +95,19 @@ export const {
           }
         )
 
-        dispatch(setItemInfo(info))
+        const examine = await runeliteApi(
+          `runelite-${version}/examine/item/${item}`,
+          {
+            method: 'GET'
+          }
+        )
+
+        dispatch(
+          setItemInfo({
+            ...info,
+            examine
+          })
+        )
       }
 
       dispatch(stopLoading())

--- a/src/modules/runelite.js
+++ b/src/modules/runelite.js
@@ -81,34 +81,28 @@ export const {
     },
     GET_ITEM_INFO: items => async (dispatch, getState) => {
       dispatch(startLoading())
-
       const version = latestReleaseSelector(getState()).name
-
-      for (let i in items) {
-        const item = items[i]
-        const info = await runeliteApi(
-          `runelite-${version}/cache/item/${item}`,
-          {
+      const result = await Promise.all(
+        items.map(item => {
+          return runeliteApi(`runelite-${version}/cache/item/${item}`, {
             method: 'GET'
-          }
-        )
-
-        const examine = await runeliteApi(
-          `runelite-${version}/examine/item/${item}`,
-          {
-            method: 'GET'
-          }
-        )
-
-        dispatch(
-          setItemInfo({
-            ...info,
-            examine
+          }).then(info => {
+            return runeliteApi(`runelite-${version}/examine/item/${item}`, {
+              method: 'GET'
+            }).then(examine => {
+              dispatch(
+                setItemInfo({
+                  ...info,
+                  examine
+                })
+              )
+            })
           })
-        )
-      }
+        })
+      )
 
       dispatch(stopLoading())
+      return result
     }
   },
   'SET_SESSION_COUNT',

--- a/src/modules/runelite.js
+++ b/src/modules/runelite.js
@@ -13,9 +13,12 @@ const runeliteApi = api('https://api.runelite.net/')
 export const {
   getSessionCount,
   getXpRange,
+  getItemInfo,
   setSessionCount,
   setXp,
-  setXpRange
+  setXpRange,
+  setItems,
+  setItemInfo
 } = createActions(
   {
     GET_SESSION_COUNT: () => async (dispatch, getState) => {
@@ -76,11 +79,33 @@ export const {
       const result = await Promise.all(results)
       dispatch(stopLoading())
       return result
+    },
+    GET_ITEM_INFO: items => async (dispatch, getState) => {
+      dispatch(startLoading())
+      dispatch(setItems())
+
+      const version = latestReleaseSelector(getState()).name
+
+      for (let i in items) {
+        const item = items[i]
+        const info = await runeliteApi(
+          `runelite-${version}/cache/item/${item}`,
+          {
+            method: 'GET'
+          }
+        )
+
+        dispatch(setItemInfo(info))
+      }
+
+      dispatch(stopLoading())
     }
   },
   'SET_SESSION_COUNT',
   'SET_XP',
-  'SET_XP_RANGE'
+  'SET_XP_RANGE',
+  'SET_ITEMS',
+  'SET_ITEM_INFO'
 )
 
 // Reducer
@@ -97,11 +122,20 @@ export default handleActions(
     [setXpRange]: (state, { payload }) => ({
       ...state,
       ...payload
+    }),
+    [setItems]: state => ({
+      ...state,
+      items: []
+    }),
+    [setItemInfo]: (state, { payload }) => ({
+      ...state,
+      items: uniq(concat(state.items, [payload]))
     })
   },
   {
     sessionCount: 0,
-    xp: []
+    xp: [],
+    items: []
   }
 )
 

--- a/src/modules/tag.js
+++ b/src/modules/tag.js
@@ -1,0 +1,15 @@
+import { createActions, handleActions } from 'redux-actions'
+
+export const { setActiveTag } = createActions('SET_ACTIVE_TAG')
+
+export default handleActions(
+  {
+    [setActiveTag]: (state, { payload }) => ({
+      ...state,
+      activeTag: payload
+    })
+  },
+  {
+    activeTag: ''
+  }
+)

--- a/src/routes/tag-show.css
+++ b/src/routes/tag-show.css
@@ -1,0 +1,20 @@
+h1 {
+  margin-top: 50px;
+}
+
+.container {
+  max-width: 705px;
+}
+
+.card {
+  margin: 10px;
+}
+
+.card img {
+  padding: 10px;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/src/routes/tag-show.css
+++ b/src/routes/tag-show.css
@@ -15,6 +15,7 @@ h1 {
 }
 
 pre {
+  user-select: all;
   white-space: pre-wrap;
   word-wrap: break-word;
 }

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux'
 import { getReleases, latestReleaseSelector } from '../modules/git'
 import { getItemInfo } from '../modules/runelite'
 import { connect } from 'preact-redux'
-import './tag-show.css'
+import './tag.css'
 
 class TagShow extends Component {
   componentDidMount() {

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -20,7 +20,7 @@ class TagShow extends Component {
     return (
       <div>
         <Meta title={`${name} tag tab - ${hero.title}`} />
-        <Layout>
+        <Layout class="tag-container">
           <h1>
             <img
               alt={''}

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -39,6 +39,10 @@ class TagShow extends Component {
               const examine = item.examine || ''
               const nameSan = name.replace(' ', '_')
 
+              if (!version.name) {
+                return <noscript />
+              }
+
               return (
                 <div class="card">
                   <div class="tooltip-tag">

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -9,6 +9,9 @@ import { connect } from 'preact-redux'
 import '../components/tooltip.css'
 import './tag.css'
 
+const formatIcon = icon =>
+  `https://raw.githubusercontent.com/Abextm/static.runelite.net/cache-code-2018-10-11-rev176/cache/item/icon/${icon}.png`
+
 class TagShow extends Component {
   componentDidMount() {
     this.props
@@ -22,13 +25,7 @@ class TagShow extends Component {
         <Meta title={`${name} tag tab - ${hero.title}`} />
         <Layout class="tag-container">
           <h1>
-            <img
-              alt={''}
-              src={`https://api.runelite.net/runelite-${
-                version.name
-              }/cache/item/${icon}/image`}
-            />{' '}
-            {name}
+            <img alt="" src={formatIcon(icon)} /> {name}
           </h1>
           <hr />
           <div class="row">
@@ -39,10 +36,6 @@ class TagShow extends Component {
               const examine = item.examine || ''
               const nameSan = name.replace(' ', '_')
 
-              if (!version.name) {
-                return <noscript />
-              }
-
               return (
                 <div class="card">
                   <div class="tooltip-tag">
@@ -50,9 +43,7 @@ class TagShow extends Component {
                       <img
                         class="card-img-top"
                         alt={name}
-                        src={`https://api.runelite.net/runelite-${
-                          version.name
-                        }/cache/item/${id}/image`}
+                        src={formatIcon(id)}
                       />
                     </a>
                     <div class="tooltip-tag-text">

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -1,0 +1,79 @@
+import { Component, h } from 'preact'
+import Layout from '../components/layout'
+import hero from '../_data/hero'
+import Meta from '../components/meta'
+import { bindActionCreators } from 'redux'
+import { getReleases, latestReleaseSelector } from '../modules/git'
+import { getItemInfo } from '../modules/runelite'
+import { connect } from 'preact-redux'
+import './tag-show.css'
+
+class TagShow extends Component {
+  componentDidMount() {
+    this.props
+      .getReleases()
+      .then(() => this.props.getItemInfo(this.props.itemIds))
+  }
+
+  render({ name, icon, itemIds, items, version, csv }) {
+    return (
+      <div>
+        <Meta title={`${name} tag tab - ${hero.title}`} />
+        <Layout>
+          <h1>
+            <img
+              src={`https://api.runelite.net/runelite-${
+                version.name
+              }/cache/item/${icon}/image`}
+            />{' '}
+            {name}
+          </h1>
+          <hr />
+          <div class="row">
+            <pre>{csv}</pre>
+            {itemIds.map(id => {
+              const item = items.find(i => i.id == id) || {}
+              const name = item.name || ''
+              const nameSan = name.replace(' ', '_')
+
+              return (
+                <div class="card">
+                  <a
+                    href={`https://oldschool.runescape.wiki/w/${nameSan}`}
+                    title={name}
+                  >
+                    <img
+                      class="card-img-top"
+                      alt={name}
+                      title={name}
+                      src={`https://api.runelite.net/runelite-${
+                        version.name
+                      }/cache/item/${id}/image`}
+                    />
+                  </a>
+                </div>
+              )
+            })}
+          </div>
+        </Layout>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  (state, { csv }) => {
+    const parts = csv.split(',')
+    const name = parts.shift()
+    const icon = parts.shift()
+
+    return {
+      name,
+      icon,
+      itemIds: parts,
+      items: state.runelite.items || [],
+      version: latestReleaseSelector(state)
+    }
+  },
+  dispatch => bindActionCreators({ getReleases, getItemInfo }, dispatch)
+)(TagShow)

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -22,6 +22,7 @@ class TagShow extends Component {
         <Layout>
           <h1>
             <img
+              alt={''}
               src={`https://api.runelite.net/runelite-${
                 version.name
               }/cache/item/${icon}/image`}
@@ -32,7 +33,7 @@ class TagShow extends Component {
           <div class="row">
             <pre>{csv}</pre>
             {itemIds.map(id => {
-              const item = items.find(i => i.id == id) || {}
+              const item = items.find(i => i.id === parseInt(id, 10)) || {}
               const name = item.name || ''
               const nameSan = name.replace(' ', '_')
 

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux'
 import { getReleases, latestReleaseSelector } from '../modules/git'
 import { getItemInfo } from '../modules/runelite'
 import { connect } from 'preact-redux'
+import '../components/tooltip.css'
 import './tag.css'
 
 class TagShow extends Component {
@@ -32,32 +33,33 @@ class TagShow extends Component {
           <hr />
           <div class="row">
             <pre>{csv}</pre>
-            {itemIds
-              .map(id => parseInt(id, 10))
-              .sort((a, b) => a - b)
-              .map(id => {
-                const item = items.find(i => i.id === id) || {}
-                const name = item.name || ''
-                const nameSan = name.replace(' ', '_')
+            {itemIds.map(id => {
+              const item = items.find(i => i.id === id) || {}
+              const name = item.name || ''
+              const examine = item.examine || ''
+              const nameSan = name.replace(' ', '_')
 
-                return (
-                  <div class="card">
-                    <a
-                      href={`https://oldschool.runescape.wiki/w/${nameSan}`}
-                      title={name}
-                    >
+              return (
+                <div class="card">
+                  <div class="tooltip-tag">
+                    <a href={`https://oldschool.runescape.wiki/w/${nameSan}`}>
                       <img
                         class="card-img-top"
                         alt={name}
-                        title={name}
                         src={`https://api.runelite.net/runelite-${
                           version.name
                         }/cache/item/${id}/image`}
                       />
                     </a>
+                    <div class="tooltip-tag-text">
+                      <b>{item.name || 'Loading...'}</b>
+                      <br />
+                      <small>{examine}</small>
+                    </div>
                   </div>
-                )
-              })}
+                </div>
+              )
+            })}
           </div>
         </Layout>
       </div>
@@ -67,9 +69,10 @@ class TagShow extends Component {
 
 export default connect(
   (state, { csv }) => {
-    const parts = csv.split(',')
+    let parts = csv.split(',')
     const name = parts.shift()
     const icon = parts.shift()
+    parts = parts.map(id => parseInt(id, 10)).sort((a, b) => a - b)
 
     return {
       name,

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -32,29 +32,32 @@ class TagShow extends Component {
           <hr />
           <div class="row">
             <pre>{csv}</pre>
-            {itemIds.map(id => {
-              const item = items.find(i => i.id === parseInt(id, 10)) || {}
-              const name = item.name || ''
-              const nameSan = name.replace(' ', '_')
+            {itemIds
+              .map(id => parseInt(id, 10))
+              .sort((a, b) => a - b)
+              .map(id => {
+                const item = items.find(i => i.id === id) || {}
+                const name = item.name || ''
+                const nameSan = name.replace(' ', '_')
 
-              return (
-                <div class="card">
-                  <a
-                    href={`https://oldschool.runescape.wiki/w/${nameSan}`}
-                    title={name}
-                  >
-                    <img
-                      class="card-img-top"
-                      alt={name}
+                return (
+                  <div class="card">
+                    <a
+                      href={`https://oldschool.runescape.wiki/w/${nameSan}`}
                       title={name}
-                      src={`https://api.runelite.net/runelite-${
-                        version.name
-                      }/cache/item/${id}/image`}
-                    />
-                  </a>
-                </div>
-              )
-            })}
+                    >
+                      <img
+                        class="card-img-top"
+                        alt={name}
+                        title={name}
+                        src={`https://api.runelite.net/runelite-${
+                          version.name
+                        }/cache/item/${id}/image`}
+                      />
+                    </a>
+                  </div>
+                )
+              })}
           </div>
         </Layout>
       </div>

--- a/src/routes/tag.css
+++ b/src/routes/tag.css
@@ -1,8 +1,5 @@
-h1 {
-  margin-top: 50px;
-}
-
 .container {
+  padding-top: 150px !important;
   max-width: 705px;
 }
 

--- a/src/routes/tag.css
+++ b/src/routes/tag.css
@@ -1,18 +1,16 @@
-.container {
+.tag-container {
   padding-top: 150px !important;
   max-width: 705px;
 }
 
-.card {
+.tag-container .card {
   margin: 10px;
 }
 
-.card img {
+.tag-container .card img {
   padding: 10px;
 }
 
-pre {
+.tag-container pre {
   user-select: all;
-  white-space: pre-wrap;
-  word-wrap: break-word;
 }

--- a/src/routes/tag.js
+++ b/src/routes/tag.js
@@ -1,0 +1,43 @@
+import { Component, h } from 'preact'
+import Layout from '../components/layout'
+import hero from '../_data/hero'
+import Meta from '../components/meta'
+import { bindActionCreators } from 'redux'
+import './tag.css'
+import { setActiveTag } from '../modules/tag'
+import { connect } from 'preact-redux'
+
+class Tag extends Component {
+  render({ activeTag, setActiveTag }) {
+    return (
+      <div>
+        <Meta title={`Select tag tab - ${hero.title}`} />
+        <Layout>
+          <h5>
+            Enter tag <br />
+            <small class="text-muted">
+              Paste tag exported from RuneLite to clipboard in text area below
+              and click GO
+            </small>
+          </h5>
+          <hr />
+          <textarea
+            rows="5"
+            class="form-control"
+            onChange={event => setActiveTag(event.target.value)}
+          >
+            {activeTag}
+          </textarea>
+          <a class="btn btn-block btn-success" href={`/tag/show/${activeTag}`}>
+            Go
+          </a>
+        </Layout>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  state => ({ activeTag: state.tag.activeTag }),
+  dispatch => bindActionCreators({ setActiveTag }, dispatch)
+)(Tag)

--- a/src/routes/tag.js
+++ b/src/routes/tag.js
@@ -12,7 +12,7 @@ class Tag extends Component {
     return (
       <div>
         <Meta title={`Select tag tab - ${hero.title}`} />
-        <Layout>
+        <Layout class="tag-container">
           <h5>
             Enter tag <br />
             <small class="text-muted">

--- a/src/routes/tag.js
+++ b/src/routes/tag.js
@@ -16,8 +16,8 @@ class Tag extends Component {
           <h5>
             Enter tag <br />
             <small class="text-muted">
-              Paste tag exported from RuneLite to clipboard in text area below
-              and click GO
+              Paste a tag exported from Runelite's Bank Tags plugin and click
+              'GO'
             </small>
           </h5>
           <hr />


### PR DESCRIPTION
This adds ability to view clipboard output of https://github.com/runelite/runelite/pull/6024

Example:
```
http://localhost:3000/tag/show/raids,19481,8842,3024,22109,12899,11771,19553,19547,12018,12006,12002,13441,12695,6739,5952,21795,12625,12612,11889,6570,12954,12926,11804,12797,12791,19933,13073,13072,19484,19481,11665,11664,11663,13393,2444,6685
```

+ added endpoint for `/tag` so you can enter tag there

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:

![screenie2](https://user-images.githubusercontent.com/5115805/47007067-b67f4280-d137-11e8-8e4a-25b927646d48.png)

![screenie1](https://user-images.githubusercontent.com/5115805/47007068-b67f4280-d137-11e8-81ca-79267ee37d3d.png)
