### PR TITLE
Move social icons at right and remove descriptions

### DIFF
--- a/src/_data/links.js
+++ b/src/_data/links.js
@@ -1,5 +1,6 @@
 export default {
   discord: 'https://discord.gg/mePCs8U',
   patreon: 'https://www.patreon.com/runelite',
-  twitter: 'https://twitter.com/RuneLiteClient'
+  twitter: 'https://twitter.com/RuneLiteClient',
+  github: 'https://github.com/runelite'
 }

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -59,26 +59,29 @@ const Navigation = ({ stars, dark }) => (
             <i class="fas fa-code" /> Tags
           </Link>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href={links.discord}>
-            <i class="fab fa-discord" /> Discord
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href={links.twitter}>
-            <i class="fab fa-twitter" /> Twitter
-          </a>
-        </li>
       </ul>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link" href={links.patreon}>
-            <i class="fab fa-patreon" /> Become a patron
+          <a class="nav-link" href={links.discord} title="Discord">
+            <i class="fab fa-discord" />
+            <span class="d-lg-none"> Discord</span>
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="https://github.com/runelite">
-            <i class="fab fa-github" /> GitHub
+          <a class="nav-link" href={links.twitter} title="Twitter">
+            <i class="fab fa-twitter" />
+            <span class="d-lg-none"> Twitter</span>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href={links.github} title="GitHub">
+            <i class="fab fa-github" />
+            <span class="d-lg-none"> GitHub</span>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href={links.patreon}>
+            <i class="fab fa-patreon" /> Become a patron
           </a>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
In order to reduce navigation bar bloat, move all social icons (Discord,
Twitter, GitHub) on right and remove their descriptions (leave just
icons).

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Preview:
![screenie](https://user-images.githubusercontent.com/5115805/47206163-38fe4100-d388-11e8-9fe3-3412bab39656.png)
