### PR TITLE
Apply markdown-body max img width also on home

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -35,6 +35,10 @@ body,
   height: 100% !important;
 }
 
+.markdown-body img {
+  max-width: 100%;
+}
+
 .card,
 .card-img-top,
 .list-group-item:first-child,

--- a/src/routes/blog-show.css
+++ b/src/routes/blog-show.css
@@ -1,3 +1,0 @@
-.markdown-body img {
-  max-width: 100%;
-}

--- a/src/routes/blog-show.js
+++ b/src/routes/blog-show.js
@@ -5,7 +5,6 @@ import blog from '../blog'
 import hero from '../_data/hero'
 import Meta from '../components/meta'
 import Async from '../components/async'
-import './blog-show.css'
 
 const BlogShow = ({ id }) => (
   <Async


### PR DESCRIPTION
In addition to applying max-width: 100% for responsive images in blog
posts, apply this rule to home page blog post too.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>