### PR TITLE
Remove type=button from website button links

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -33,7 +33,7 @@ pre {
 
 .dropdown:hover .dropdown-menu {
   display: block;
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 .icon {

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -121,14 +121,12 @@ class Hero extends Component {
             <p class="lead">
               <div class="btn-group dropdown">
                 <a
-                  type="button"
                   class={'btn btn-' + mainDropdownItem.color}
                   href={mainDropdownItem.link}
                 >
                   <i class={mainDropdownItem.icon} /> {mainDropdownItem.text}
                 </a>
                 <button
-                  type="button"
                   class={
                     'btn dropdown-toggle dropdown-toggle-split btn-' +
                     mainDropdownItem.color
@@ -147,7 +145,7 @@ class Hero extends Component {
               {regularButtons.map(({ link, color, icon, text }) => (
                 <span key={link}>
                   {' '}
-                  <a type="button" class={'btn btn-' + color} href={link}>
+                  <a class={'btn btn-' + color} href={link}>
                     <i class={icon} /> {text}
                   </a>
                   <br style={{ marginBottom: 10 }} class="d-md-none" />


### PR DESCRIPTION
This removes weird gradient that is happening only on webkit-based
browsers.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>