### PR TITLE
Bump Bootstrap to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2684,9 +2684,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
-      "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.7.1",
     "@gouch/to-title-case": "2.2.1",
-    "bootstrap": "4.2.1",
+    "bootstrap": "4.3.1",
     "dayjs": "1.8.5",
     "platform": "1.3.5",
     "preact": "8.4.2",


### PR DESCRIPTION
To resolve XSS security vulnerability listed here:
https://nvd.nist.gov/vuln/detail/CVE-2019-8331.

We don't use tooltips and tooltip-data properties from Bootstrap JS, but
its still better to just update.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>