### PR TITLE
Put personal best before kill count

### DIFF
--- a/src/routes/account/home.js
+++ b/src/routes/account/home.js
@@ -149,17 +149,18 @@ const buildBossLog = bossLog => {
             />
             {e.name.toTitleCase()}{' '}
             <div class="float-right">
-              Kills: <span class="badge badge-primary badge-pill">{e.kc}</span>{' '}
               {e.pb ? (
                 <span>
                   Personal best:{' '}
                   <span class="badge badge-info badge-pill">
+                    {' '}
                     {toMMSS(e.pb)}
-                  </span>
+                  </span>{' '}
                 </span>
               ) : (
                 <noscript />
               )}
+              Kills: <span class="badge badge-primary badge-pill">{e.kc}</span>{' '}
             </div>
           </li>
         ))}


### PR DESCRIPTION
As kill count is always present but PB might be not (because very often
bosses dont have it) just put it on left so kc are always at same place.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>