### PR TITLE
blog post: Add precise date as title attribute on date

### DIFF
--- a/src/routes/blog-show.js
+++ b/src/routes/blog-show.js
@@ -24,7 +24,7 @@ const buildPost = ({ date, title, description, author, body }) => {
       />
       <h1>{title}</h1>
       <p class="text-muted">
-        {ago(date)} by {author}
+        <span title={date}>{ago(date)}</span> by {author}
       </p>
       <hr />
       <div class="markdown-body">


### PR DESCRIPTION
This adds a title in the form "Fri May 03 2019 10:00:00 GMT+0000 (Coordinated Universal Time)" to the post date. (that is, the default String cast of the Date object)

Closes #233