### PR TITLE
Fix: JSON exports reach maximum length and download fails

### DIFF
--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -82,9 +82,11 @@ const menuBody = currentMenu => currentMenu.component
 const menuExport = (currentMenu, props) => {
   const currentSelector = currentMenu.data
   const dataJson = currentSelector(props)
-  const data =
-    'data:application/json;charset=utf-8,' +
-    encodeURIComponent(JSON.stringify(dataJson))
+  const data = URL.createObjectURL(
+    new Blob([JSON.stringify(dataJson)], {
+      type: 'application/octet-stream'
+    })
+  )
   return (
     <a
       class="list-group-item list-group-item-primary"


### PR DESCRIPTION
If you have loot tracker with a decent amount of loot, the Export feature doesnt work as the data becomes too big to download with a URI.

Example:
![image](https://user-images.githubusercontent.com/30398469/64475258-bced3180-d1c3-11e9-870e-6f5dddf66655.png)
