### PR TITLE
Removed total charts when selecting specific skill

### DIFF
--- a/src/routes/xp-show.js
+++ b/src/routes/xp-show.js
@@ -74,6 +74,59 @@ const XpShow = ({ name, skill, xp, collectedXp, start, end }) => {
   }
 
   const { startDate, endDate } = createDateRange(start, end)
+
+  const renderTotalCharts = () => {
+    return (
+      <div>
+        <h5>
+          <small>Total experience gained</small>
+        </h5>
+        <ResponsiveContainer height={300}>
+          <BarChart
+            data={skillNames
+              .filter(skill => skill !== 'overall')
+              .map(skill => ({
+                name: skill.toTitleCase(),
+                value: collectedXp[skill] ? collectedXp[skill].xp : 0
+              }))}
+          >
+            <XAxis dataKey="name" />
+            <YAxis hide />
+            <Tooltip />
+            <Bar dataKey="value">
+              {skillNames
+                .filter(skill => skill !== 'overall')
+                .map(skill => (
+                  <Cell fill={skills[skill]} />
+                ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+
+        <h5>
+          <small>Total ranks gained</small>
+        </h5>
+        <ResponsiveContainer height={300}>
+          <BarChart
+            data={skillNames.map(skill => ({
+              name: skill.toTitleCase(),
+              value: collectedXp[skill] ? collectedXp[skill].rank : 0
+            }))}
+          >
+            <XAxis dataKey="name" />
+            <YAxis hide />
+            <Tooltip />
+            <Bar dataKey="value">
+              {skillNames.map(skill => (
+                <Cell fill={skills[skill]} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    )
+  }
+
   return (
     <Layout>
       <Meta title={`Experience Tracker - ${hero.title}`} />
@@ -118,51 +171,7 @@ const XpShow = ({ name, skill, xp, collectedXp, start, end }) => {
           </ul>
         </div>
         <div class="col-xl-9 col-md-8 col-sm-12 col-xs-12">
-          <h5>
-            <small>Total experience gained</small>
-          </h5>
-          <ResponsiveContainer height={300}>
-            <BarChart
-              data={skillNames
-                .filter(skill => skill !== 'overall')
-                .map(skill => ({
-                  name: skill.toTitleCase(),
-                  value: collectedXp[skill] ? collectedXp[skill].xp : 0
-                }))}
-            >
-              <XAxis dataKey="name" />
-              <YAxis hide />
-              <Tooltip />
-              <Bar dataKey="value">
-                {skillNames
-                  .filter(skill => skill !== 'overall')
-                  .map(skill => (
-                    <Cell fill={skills[skill]} />
-                  ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-
-          <h5>
-            <small>Total ranks gained</small>
-          </h5>
-          <ResponsiveContainer height={300}>
-            <BarChart
-              data={skillNames.map(skill => ({
-                name: skill.toTitleCase(),
-                value: collectedXp[skill] ? collectedXp[skill].rank : 0
-              }))}
-            >
-              <XAxis dataKey="name" />
-              <YAxis hide />
-              <Tooltip />
-              <Bar dataKey="value">
-                {skillNames.map(skill => (
-                  <Cell fill={skills[skill]} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          {skill === 'overall' && renderTotalCharts()}
 
           <h5>
             <small>{skill.toTitleCase()} ranks</small>


### PR DESCRIPTION
Hides the overall skill charts when selecting one of the specific skills in the sidebar.

Can be seen here:
https://5d9f4c73fc931a0009afe5bf--runelite.netlify.com/xp/show/agility/mgby/1569837845168/1570442645168

Closes #262 