### PR TITLE
Use /discord link for Discord invites in navbar

### DIFF
--- a/redirect.js
+++ b/redirect.js
@@ -1,5 +1,5 @@
 module.exports = {
-  discord: 'https://discord.gg/ArdAhnN',
+  discord: 'https://discord.gg/mePCs8U',
   'redirect/launcher/discord': 'https://discord.gg/ArdAhnN',
   'redirect/launcher/troubleshooting':
     'https://github.com/runelite/runelite/wiki/Troubleshooting-problems-with-the-client'

--- a/src/_data/links.js
+++ b/src/_data/links.js
@@ -1,5 +1,4 @@
 export default {
-  discord: 'https://discord.gg/mePCs8U',
   patreon: 'https://www.patreon.com/runelite',
   twitter: 'https://twitter.com/RuneLiteClient',
   github: 'https://github.com/runelite'

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -97,7 +97,7 @@ const Navigation = ({ dark, login, loggedIn, username }) => (
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link nav-icon" href={links.discord} title="Discord">
+          <a class="nav-link nav-icon" href="/discord" title="Discord">
             <i class="fab fa-discord" />
             <span class="d-lg-none"> Discord</span>
           </a>


### PR DESCRIPTION
- Switch from links.discord to /discord redirect in navbar
- Remove links.discord

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>