### PR TITLE
Fix homepage header display on mobile devices

### DIFF
--- a/src/components/hero.css
+++ b/src/components/hero.css
@@ -6,9 +6,23 @@
   width: 100%;
   margin: 0;
   height: calc(100vh - 55px);
-  background: rgba(0, 0, 0, 0.2) no-repeat center center fixed;
+  background: rgba(0, 0, 0, 0.2);
+  background-position-x: center;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  -ms-background-size: cover;
+  -o-background-size: cover;
+  -moz-background-size: cover;
+  -webkit-background-size: cover;
   background-size: cover;
-  padding-bottom: 0px;
+  padding-bottom: 0;
+}
+
+@media screen and (max-device-width: 1024px) {
+  .jumbotron {
+    background-attachment: scroll;
+  }
 }
 
 .jumbotron-cell {

--- a/src/routes/account/loot-tracker.js
+++ b/src/routes/account/loot-tracker.js
@@ -145,7 +145,11 @@ const mapDispatchToProps = dispatch =>
     dispatch
   )
 
-const prepareComponentData = async ({ fetchBootstrap, fetchPrices, fetchLoot }) => {
+const prepareComponentData = async ({
+  fetchBootstrap,
+  fetchPrices,
+  fetchLoot
+}) => {
   await fetchBootstrap()
   await fetchPrices()
   await fetchLoot()

--- a/src/util.js
+++ b/src/util.js
@@ -39,5 +39,7 @@ export const toMMSS = s => {
 export const wikiURLForItem = ({ id, name }) => {
   // This should canonicalize the name, but the website doesn't have that information as of writing
   // It only really matters if there are noted items with ambiguous names, so I don't think it matters here
-  return `https://oldschool.runescape.wiki/w/Special:Lookup?type=item&id=${id}&name=${encodeURIComponent(name)}&utm_source=runelite.net`
+  return `https://oldschool.runescape.wiki/w/Special:Lookup?type=item&id=${id}&name=${encodeURIComponent(
+    name
+  )}&utm_source=runelite.net`
 }


### PR DESCRIPTION
Some browsers on mobile devices do not really support
background-attachment fixed because of performance reasons, so simply
disable it. Also add some other compatiblity stuff just in case.

Related stackoverflow post:

https://stackoverflow.com/questions/20443574/fixed-background-image-with-ios7

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>