### PR TITLE
Reset scroll position of blog posts

### DIFF
--- a/src/routes/blog-show.js
+++ b/src/routes/blog-show.js
@@ -12,6 +12,9 @@ const InnerHTMLHelper = ({ tagName, html }) =>
   h(tagName, { dangerouslySetInnerHTML: { __html: html } })
 
 const buildPost = ({ date, title, description, author, body }) => {
+  // The blog uses the current scroll position when going into a post.
+  // Reset it to top by hand.
+  window.scrollTo(0, 0)
   if (!body) {
     return <NotFound />
   }


### PR DESCRIPTION
Closes #284

Scroll state isn't correctly maintained by this SPA, so reset it when going into blog posts.