### PR TITLE
Disable minification of atom.xml

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -122,6 +122,7 @@ const addSitePlugins = () => config => {
       },
       template: 'public/atom.html',
       filename: 'atom.xml',
+      minify: false,
       inject: false,
       xhtml: false
     })


### PR DESCRIPTION
Because apparently minify means break.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>