### PR TITLE
Fix the Discord link in the navigation pane.

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -97,7 +97,7 @@ const Navigation = ({ dark, login, loggedIn, username }) => (
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link nav-icon" href="/discord" title="Discord">
+          <a class="nav-link nav-icon" href="https://runelite.net/discord" title="Discord">
             <i class="fab fa-discord" />
             <span class="d-lg-none"> Discord</span>
           </a>


### PR DESCRIPTION
Whilst on the RuneLite homepage, clicking the Discord button in the navigation pane doesn't work. From what I can tell, some JavaScript in React is hijacking the click function. With all JS disabled, the button works as expected. I noticed that setting the link to the Discord redirect page as an absolute link fixes this problem, although there is likely a better way of fixing this issue. Unfortunately I don't know React, which may have it's own conventions to fix this, but this is good enough IMO.

