### PR TITLE
Ability to search loot tracker by item name

### DIFF
--- a/src/modules/loot.js
+++ b/src/modules/loot.js
@@ -112,7 +112,11 @@ export const getFilteredLoot = createSelector(
       .filter(
         l =>
           !filter.name ||
-          l.eventId.toLowerCase().indexOf(filter.name.toLowerCase()) !== -1
+          l.eventId.toLowerCase().indexOf(filter.name.toLowerCase()) !== -1 ||
+          l.drops.filter(
+            drop =>
+              drop.name.toLowerCase().indexOf(filter.name.toLowerCase()) !== -1
+          ).length >= 1
       )
       .sort((a, b) => b.date - a.date)
 )


### PR DESCRIPTION
Adding ability to search loot tracker by item name

![image](https://user-images.githubusercontent.com/6834228/75594379-709ef200-5a80-11ea-95bf-ded45337eaf6.png)

![image](https://user-images.githubusercontent.com/6834228/75594404-857b8580-5a80-11ea-8aff-7b71b4bcd785.png)
