### PR TITLE
Make all links orange

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -11,6 +11,10 @@
   src: url(~lato-font/fonts/lato-normal/lato-normal.woff);
 }
 
+a {
+  color: #dc8a00;
+}
+
 html,
 body,
 #root {


### PR DESCRIPTION
This was previously set only for blog posts in blog/show, so for
consistency use same color everywhere.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>