### PR TITLE
Add /pulse page

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -33,6 +33,7 @@ const App = ({ loading, navbarDark, login, logout, loggedIn, username }) => (
         path="/features"
         getComponent={() => import('../routes/features')}
       />
+      <Async path="/pulse" getComponent={() => import('../routes/pulse')} />
       <Async
         path="/plugin-hub"
         getComponent={() => import('../routes/plugin-hub')}

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -81,3 +81,16 @@ pre {
   font-size: x-small;
   font-weight: normal;
 }
+
+.list-group-item {
+  margin-bottom: 15px;
+  background: #141414 !important;
+  border-radius: 5px;
+}
+
+.list-group-item:hover,
+.list-group-item:active,
+.list-group-item-action:hover,
+.list-group-item-action:active {
+  background: #101010 !important;
+}

--- a/src/components/commit.js
+++ b/src/components/commit.js
@@ -1,11 +1,11 @@
 import { h, Fragment } from 'preact'
 import ago from 's-ago'
 
-const Commit = ({ url, message, author, date }) =>
+const Commit = ({ url, title, author, date }) =>
   url && (
     <Fragment>
       <h6>Latest commit:</h6>
-      <a href={url}>{message}</a>{' '}
+      <a href={url}>{title}</a>{' '}
       <span class="text-muted">
         by <a href={author.url ? author.url : url}>{author.name},</a>{' '}
         {ago(date)}

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -49,6 +49,16 @@ const Navigation = ({ dark, login, loggedIn, username }) => (
           </Link>
         </li>
         <li class="nav-item">
+          <Link
+            onClick={toggleMenu}
+            class="nav-link"
+            activeClassName="active"
+            href="/pulse"
+          >
+            Pulse
+          </Link>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="https://github.com/runelite/runelite/wiki">
             Wiki
           </a>

--- a/src/middleware/thunk-middleware.js
+++ b/src/middleware/thunk-middleware.js
@@ -10,7 +10,10 @@ function wrapAsync(dispatch, getState, action) {
         dispatch(stopLoading())
         return r
       })
-      .catch(() => dispatch(stopLoading()))
+      .catch(e => {
+        dispatch(stopLoading())
+        return e
+      })
   }
 
   dispatch(stopLoading())

--- a/src/routes/blog.scss
+++ b/src/routes/blog.scss
@@ -21,16 +21,6 @@
   }
 }
 
-#blog-list .list-group-item {
-  margin-bottom: 15px;
-  background: #141414;
-  border-radius: 5px;
-}
-
-#blog-list .list-group-item:hover {
-  background: #101010;
-}
-
 #blog-list h5 {
   color: white;
 }

--- a/src/routes/pulse.js
+++ b/src/routes/pulse.js
@@ -1,0 +1,267 @@
+import { h, Fragment } from 'preact'
+import './home.scss'
+import './blog.scss'
+import { connect } from 'react-redux'
+import Layout from '../components/layout'
+import {
+  fetchCommits,
+  fetchIssues,
+  fetchPulls,
+  fetchReleases,
+  getClosedIssues,
+  getCommits,
+  getDetails,
+  getLatestRelease,
+  getMergedPullsSinceLastRelease,
+  getOpenedIssues,
+  getOpenedPullsSinceLastRelease
+} from '../modules/git'
+import hero from '../_data/hero'
+import Meta from '../components/meta'
+import { bindActionCreators } from 'redux'
+import prepare from '../components/prepare'
+import { numberWithCommas } from '../util'
+import ago from 's-ago'
+import { fetchBootstrap } from '../modules/bootstrap'
+
+const typeMap = {
+  merged: '#6f42c1',
+  open: '#2cbe4e',
+  draft: '#c6c6c6',
+  closed: '#cb2431'
+}
+
+const buildLabels = pull =>
+  pull.labels &&
+  pull.labels.map(label => (
+    <Fragment>
+      {' '}
+      <span
+        class="badge"
+        style={{ color: 'black', backgroundColor: '#' + label.color }}
+      >
+        {label.name}
+      </span>
+    </Fragment>
+  ))
+
+const buildPull = (pull, type) => (
+  <a
+    class="list-group-item list-group-item-action"
+    style={{
+      borderLeft: `5px solid ${
+        !pull.mergedAt && pull.closedAt
+          ? typeMap.closed
+          : pull.draft
+          ? typeMap.draft
+          : typeMap[type]
+      }`,
+      color: 'white'
+    }}
+    href={pull.url}
+  >
+    {pull.title} {buildLabels(pull)}
+    <br />
+    <span class="text-muted">
+      {ago(
+        pull.mergedAt
+          ? pull.mergedAt
+          : pull.closedAt
+          ? pull.closedAt
+          : pull.createdAt
+      )}
+    </span>
+  </a>
+)
+
+const Pulse = ({
+  details,
+  commits,
+  release,
+  mergedPulls,
+  openedPulls,
+  closedIssues,
+  openedIssues
+}) =>
+  release.date && (
+    <Layout>
+      <Meta title={`Pulse - ${hero.title}`} />
+
+      <section id="pulse">
+        <div
+          class="content-section"
+          style={{
+            maxWidth: '100%'
+          }}
+        >
+          <div class="page-header">
+            <h1>Activity since the {release.name} release</h1>
+            <p class="text-muted">
+              From <b>{release.date.toDateString()}</b> to{' '}
+              <b>{new Date().toDateString()}</b>
+            </p>
+          </div>
+
+          <div
+            class="progress page-header"
+            title="Open issues and pull requests"
+            style={{
+              backgroundColor: typeMap.open
+            }}
+          >
+            <div
+              class="progress-bar"
+              title="Merged pull requests"
+              style={{
+                width:
+                  (mergedPulls.length /
+                    (mergedPulls.length +
+                      openedPulls.length +
+                      closedIssues.length +
+                      openedIssues.length)) *
+                    100 +
+                  '%',
+                backgroundColor: typeMap.merged
+              }}
+            />
+            <div
+              class="progress-bar"
+              title="Closed issues"
+              style={{
+                width:
+                  (closedIssues.length /
+                    (mergedPulls.length +
+                      openedPulls.length +
+                      closedIssues.length +
+                      openedIssues.length)) *
+                    100 +
+                  '%',
+                backgroundColor: typeMap.closed
+              }}
+            />
+          </div>
+
+          <div class="page-header">
+            Excluding merges, <b>{details.commits} commits</b> from{' '}
+            <b>{details.authors} authors</b> have been pushed to master. On
+            master, <b>{details.files} files</b> have changed and there have
+            been{' '}
+            <b>
+              <span class="text-success">
+                {numberWithCommas(details.additions)}
+              </span>{' '}
+              additions
+            </b>{' '}
+            and{' '}
+            <b>
+              <span class="text-danger">
+                {numberWithCommas(details.deletions)}
+              </span>{' '}
+              deletions
+            </b>
+            .
+          </div>
+
+          <div class="row page-header">
+            <div class="col-md-6">
+              <h1 class="page-header">
+                <b>{mergedPulls.length}</b> pull requests merged
+              </h1>
+              <ul class="list-group">
+                {mergedPulls.map(pull => buildPull(pull, 'merged'))}
+              </ul>
+            </div>
+            <div class="col-md-6">
+              <h1 class="page-header">
+                <b>{openedPulls.length}</b> pull requests opened
+              </h1>
+              <ul class="list-group">
+                {openedPulls.map(pull => buildPull(pull, 'open'))}
+              </ul>
+            </div>
+          </div>
+
+          <div class="row page-header">
+            <div class="col-md-6">
+              <h1 class="page-header">
+                <b>{closedIssues.length}</b> issues closed
+              </h1>
+              <ul class="list-group">
+                {closedIssues.map(pull => buildPull(pull, 'closed'))}
+              </ul>
+            </div>
+            <div class="col-md-6">
+              <h1 class="page-header">
+                <b>{openedIssues.length}</b> issues opened
+              </h1>
+              <ul class="list-group">
+                {openedIssues.map(pull => buildPull(pull, 'open'))}
+              </ul>
+            </div>
+          </div>
+
+          <h1 class="page-header">
+            <b>{commits.length}</b> new commits
+          </h1>
+          <ul class="list-group">
+            {commits.map(commit => {
+              return (
+                <a
+                  class="list-group-item list-group-item-action"
+                  style={{
+                    color: 'white'
+                  }}
+                  href={commit.url}
+                >
+                  {commit.title}
+                  <br />
+                  <span class="text-muted">by {commit.author.name}</span>
+                </a>
+              )
+            })}
+          </ul>
+        </div>
+      </section>
+    </Layout>
+  )
+
+const mapStateToProps = state => ({
+  commits: getCommits(state),
+  mergedPulls: getMergedPullsSinceLastRelease(state),
+  openedPulls: getOpenedPullsSinceLastRelease(state),
+  closedIssues: getClosedIssues(state),
+  openedIssues: getOpenedIssues(state),
+  release: getLatestRelease(state),
+  details: getDetails(state)
+})
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      fetchBootstrap,
+      fetchCommits,
+      fetchPulls,
+      fetchReleases,
+      fetchIssues
+    },
+    dispatch
+  )
+
+const prepareComponentData = async ({
+  fetchBootstrap,
+  fetchCommits,
+  fetchPulls,
+  fetchReleases,
+  fetchIssues
+}) => {
+  await fetchBootstrap()
+  await fetchReleases()
+  fetchCommits()
+  fetchPulls()
+  fetchIssues()
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(prepare(prepareComponentData)(Pulse))

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
 import { applyMiddleware, combineReducers, createStore } from 'redux'
-import { persistStore, persistReducer } from 'redux-persist'
+import { persistStore, persistReducer, createTransform } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
 import thunkMiddleware from './middleware/thunk-middleware'
 import rootReducer from './modules'
@@ -25,10 +25,22 @@ export default callback => {
   // Enable persisted reducer
   const persistedReducer = persistReducer(
     {
-      key: 'account',
+      key: 'runelite',
       storage,
       debug: isDebug,
-      whitelist: ['account']
+      whitelist: ['account', 'git'],
+      // Transform dates back into JS Dates on rehydrate
+      // (see: https://github.com/rt2zz/redux-persist/issues/82)
+      transforms: [
+        createTransform(JSON.stringify, toRehydrate =>
+          JSON.parse(toRehydrate, (key, value) =>
+            typeof value === 'string' &&
+            value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+              ? new Date(value)
+              : value
+          )
+        )
+      ]
     },
     reducer
   )


### PR DESCRIPTION
Pulse page shows list of merged and opened pull requests and new commits
since last release.

In my opinion this is very nice page to have for people to see what is coming in next release and also for developers writing blog posts. I am not sure what else it can show so suggestions are welcome.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>