### PR TITLE
Fix tooltip display when out of parent div

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -91,7 +91,7 @@ footer hr {
   background: #232323;
   color: white;
   padding: 100px 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 @include media-breakpoint-down(md) {

--- a/src/components/tooltip.css
+++ b/src/components/tooltip.css
@@ -1,4 +1,3 @@
-/* Tooltip text */
 .tooltip-tag .tooltip-tag-text {
   padding: 5px;
   visibility: hidden;
@@ -10,15 +9,13 @@
   line-height: normal;
   font-size: smaller;
 
-  /* Position the tooltip text - see examples below! */
-  bottom: 100%;
+  bottom: 110%;
   left: 50%;
-  margin-left: -60px; /* Use half of the width (120/2 = 60), to center the tooltip */
+  margin-left: -50%;
   position: absolute;
-  z-index: 1;
+  z-index: 1000;
 }
 
-/* Show the tooltip text when you mouse over the tooltip container */
 .tooltip-tag:hover .tooltip-tag-text {
   visibility: visible;
 }


### PR DESCRIPTION
Change overflow of content-display to visible to allow tooltips to show
outside of it.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>