### PR TITLE
Remove extra dollar symbol from plugin-hub title

### DIFF
--- a/src/routes/plugin-hub.js
+++ b/src/routes/plugin-hub.js
@@ -28,7 +28,7 @@ const PluginHub = ({
   setPluginFilter
 }) => (
   <Layout>
-    <Meta title={`${author ? author + ' ' : ''}Plugin Hub - ${hero.title}$`} />
+    <Meta title={`${author ? author + ' ' : ''}Plugin Hub - ${hero.title}`} />
 
     <section id="externalPlugins">
       <div class="content-section">


### PR DESCRIPTION
Left it there by accident when adding interpolated author field to
title.

Oops

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>