### PR TITLE
Align tags left instead of center

### DIFF
--- a/src/routes/account/tags.js
+++ b/src/routes/account/tags.js
@@ -29,7 +29,7 @@ const buildTag = tag => {
       </h1>
 
       <pre class="pre-select">{csv}</pre>
-      <div class="row justify-content-center">
+      <div class="row pl-2">
         {tag.items.map(item => {
           const name = item.name || ''
           const id = item.id

--- a/src/routes/tag-show.js
+++ b/src/routes/tag-show.js
@@ -22,7 +22,7 @@ const TagShow = ({ name, icon, itemIds, items, csv }) => (
 
         <pre class="pre-select">{csv}</pre>
 
-        <div class="row justify-content-center">
+        <div class="row pl-2">
           {itemIds.map(id => {
             const item = items.find(i => i.id === id) || {}
             const name = item.name || ''


### PR DESCRIPTION
Instead of tags being centered on /tag/show and /account/tags, align
them left.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>