### PR TITLE
loot: make same tier clue scrolls stack

### DIFF
--- a/src/modules/loot.js
+++ b/src/modules/loot.js
@@ -144,7 +144,11 @@ export const getGroupedLoot = createSelector(getFilteredLoot, loot => {
       let found = false
 
       for (let groupedItem of groupedItems) {
-        if (item.id === groupedItem.id) {
+        if (
+          item.id === groupedItem.id ||
+          (item.name.startsWith('Clue scroll') &&
+            item.name === groupedItem.name)
+        ) {
           groupedItem.qty += item.qty
           found = true
           break


### PR DESCRIPTION
Makes the website's loot tracker more consistent with the one in the client by stacking the clue scroll drops together.