### PR TITLE
Lowercase config keys

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -35,7 +35,7 @@ export const { fetchConfig, setConfig, changeAccount } = createActions(
       const config = {}
       for (let i in result.config) {
         const kv = result.config[i]
-        config[kv.key] = kv.value
+        config[kv.key.toLowerCase()] = kv.value
       }
 
       dispatch(setConfig(config))


### PR DESCRIPTION
As usernames are case insensitive (and rest of the configs are as well on the site), lowercase all config keys when fetching
configuration.

Closes #362

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>