### PR TITLE
Add support for plugin hub user count

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -46,6 +46,10 @@ video {
   max-width: 100%;
 }
 
+.dropdown-menu {
+  min-width: 100%;
+}
+
 .dropdown:hover .dropdown-menu {
   display: block;
   margin-top: 0;
@@ -95,4 +99,8 @@ video {
 .list-group-item-action:hover,
 .list-group-item-action:active {
   background: #101010 !important;
+}
+
+.btn.disabled {
+  cursor: default;
 }

--- a/src/components/choice.js
+++ b/src/components/choice.js
@@ -1,0 +1,21 @@
+import { h } from 'preact'
+
+const Choice = ({ prefix, choices, value, onClick }) => (
+  <div class="dropdown">
+    <button
+      class="dropdown-toggle btn btn-block btn-dark"
+      id={'choice' + prefix}
+    >
+      {prefix} {value}
+    </button>
+    <div class="dropdown-menu">
+      {choices.map(choice => (
+        <button class="dropdown-item" onClick={() => onClick(choice)}>
+          {prefix} {choice}
+        </button>
+      ))}
+    </div>
+  </div>
+)
+
+export default Choice

--- a/src/components/external-plugin.js
+++ b/src/components/external-plugin.js
@@ -1,5 +1,6 @@
 import { h } from 'preact'
 import './feature.scss'
+import { numberWithCommas } from '../util'
 
 const ExternalPlugin = ({
   displayName,
@@ -7,7 +8,8 @@ const ExternalPlugin = ({
   description,
   support,
   imageUrl,
-  installed
+  installed,
+  count
 }) => (
   <div class="col-md-4 col-sm-6 col-xs-12 mb-2">
     <div class="card">
@@ -32,12 +34,20 @@ const ExternalPlugin = ({
               </a>
             ) : (
               displayName
-            )}{' '}
-            {installed && <span class="badge badge-success">installed</span>}
+            )}
           </h5>
           <h6 class="card-subtitle mb-2 text-muted">
             <a href={`/plugin-hub/${author}`}>{author}</a>
           </h6>
+          {count > 0 && (
+            <p class="card-text">
+              <span class="badge badge-primary">
+                {numberWithCommas(count)}{' '}
+                {count > 1 ? 'active installs' : 'active install'}
+              </span>{' '}
+              {installed && <span class="badge badge-success">installed</span>}
+            </p>
+          )}
           <p class="card-text">
             {description.replace(/<br\/?>/g, '\n').replace(/<[^>]+>/g, '')}
           </p>

--- a/src/routes/plugin-hub.js
+++ b/src/routes/plugin-hub.js
@@ -9,12 +9,24 @@ import Meta from '../components/meta'
 import { fetchBootstrap } from '../modules/bootstrap'
 import {
   fetchExternalPlugins,
+  fetchPluginHubStats,
   getPluginFilter,
+  getPluginSorting,
   getSortedExternalPlugins,
-  setPluginFilter
+  setPluginFilter,
+  setPluginSorting
 } from '../modules/plugin-hub'
 import SearchBar from '../components/search-bar'
 import { fetchConfig } from '../modules/config'
+import Choice from '../components/choice'
+import { numberWithCommas } from '../util'
+
+const description =
+  'The Plugin Hub is a repository of plugins that are created and ' +
+  'maintained by members of the community who are not officially ' +
+  'affiliated with RuneLite. These plugins are verified by RuneLite ' +
+  "Developers to ensure they comply with Jagex's 3rd party client rules " +
+  'and are not malicious in some other way.'
 
 const handleChange = (event, setPluginFilter) =>
   setPluginFilter({
@@ -25,48 +37,95 @@ const PluginHub = ({
   author,
   externalPlugins,
   pluginFilter,
-  setPluginFilter
-}) => (
-  <Layout>
-    <Meta title={`${author ? author + ' ' : ''}Plugin Hub - ${hero.title}`} />
+  pluginSorting,
+  setPluginFilter,
+  setPluginSorting
+}) => {
+  externalPlugins = externalPlugins.filter(plugin =>
+    author ? plugin.author === author : true
+  )
 
-    <section id="externalPlugins">
-      <div class="content-section">
-        <h1 class="page-header">{author ? author + ' ' : ''}Plugin Hub</h1>
-        <p>
-          The Plugin Hub is a repository of plugins that are created and
-          maintained by members of the community who are not officially
-          affiliated with RuneLite. These plugins are verified by RuneLite
-          Developers to ensure they comply with Jagex's 3rd party client rules
-          and are not malicious in some other way.
-        </p>
-        <p>
-          For more information about the Plugin Hub and how to install these
-          plugins read the{' '}
-          <a href="https://github.com/runelite/runelite/wiki/Information-about-the-Plugin-Hub">
-            guide on our wiki
-          </a>
-        </p>
-        <SearchBar
-          value={pluginFilter.name}
-          onInput={e => handleChange(e, setPluginFilter)}
-        />
-        <div class="row">
-          {externalPlugins
-            .filter(plugin => (author ? plugin.author === author : true))
-            .map(plugin => (
+  const pluginCount = externalPlugins.length
+  const installedPluginCount = externalPlugins.filter(p => p.installed).length
+  const totalCount = externalPlugins.reduce((a, b) => a + b.count, 0)
+
+  return (
+    <Layout>
+      <Meta
+        title={`${author ? author + ' ' : ''}Plugin Hub - ${hero.title}`}
+        description={description}
+      />
+
+      <section id="externalPlugins">
+        <div class="content-section">
+          <h1 class="page-header">{author ? author + ' ' : ''}Plugin Hub</h1>
+          <div class="row">
+            <div class="col-sm-8">
+              <p>{description}</p>
+              <p>
+                For more information about the Plugin Hub and how to install
+                these plugins, read the{' '}
+                <a href="https://github.com/runelite/runelite/wiki/Information-about-the-Plugin-Hub">
+                  guide on our wiki
+                </a>
+                .
+              </p>
+            </div>
+            <div class="col-sm-4">
+              {totalCount > 0 && (
+                <div class="btn btn-block btn-dark disabled">
+                  <b>{numberWithCommas(totalCount)}</b>{' '}
+                  {totalCount > 1 ? 'active installs' : 'active install'}
+                </div>
+              )}
+              {pluginCount > 0 && (
+                <div class="btn btn-block btn-dark disabled">
+                  <b>{numberWithCommas(pluginCount)}</b>{' '}
+                  {pluginCount > 1 ? 'plugins' : 'plugin'}
+                </div>
+              )}
+              {installedPluginCount > 0 && (
+                <div class="btn btn-block btn-dark disabled">
+                  <b>{numberWithCommas(installedPluginCount)}</b>{' '}
+                  {installedPluginCount > 1
+                    ? 'installed plugins'
+                    : 'installed plugin'}
+                </div>
+              )}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-8">
+              <SearchBar
+                value={pluginFilter.name}
+                onInput={e => handleChange(e, setPluginFilter)}
+              />
+            </div>
+            <div class="col-sm-4">
+              <Choice
+                prefix="Sort by"
+                value={pluginSorting}
+                choices={['active installs', 'name']}
+                onClick={setPluginSorting}
+              />
+            </div>
+          </div>
+          <div class="row">
+            {externalPlugins.map(plugin => (
               <ExternalPlugin key={plugin.internalName} {...plugin} />
             ))}
+          </div>
         </div>
-      </div>
-    </section>
-  </Layout>
-)
+      </section>
+    </Layout>
+  )
+}
 
 const mapStateToProps = (state, props) => ({
   ...props,
   externalPlugins: getSortedExternalPlugins(state),
-  pluginFilter: getPluginFilter(state)
+  pluginFilter: getPluginFilter(state),
+  pluginSorting: getPluginSorting(state)
 })
 
 const mapDispatchToProps = dispatch =>
@@ -75,7 +134,9 @@ const mapDispatchToProps = dispatch =>
       fetchBootstrap,
       fetchConfig,
       fetchExternalPlugins,
-      setPluginFilter
+      fetchPluginHubStats,
+      setPluginFilter,
+      setPluginSorting
     },
     dispatch
   )
@@ -83,11 +144,13 @@ const mapDispatchToProps = dispatch =>
 const prepareComponentData = async ({
   fetchBootstrap,
   fetchConfig,
-  fetchExternalPlugins
+  fetchExternalPlugins,
+  fetchPluginHubStats
 }) => {
   await fetchBootstrap()
   await fetchConfig()
   await fetchExternalPlugins()
+  await fetchPluginHubStats()
 }
 
 export default connect(


### PR DESCRIPTION
- Add user counter next to each plugin
- Add support for sorting by name or user count

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>