### PR TITLE
Temporarily switch to 1.6.30-SNAPSHOT for plugin hub stats

### DIFF
--- a/src/modules/plugin-hub.js
+++ b/src/modules/plugin-hub.js
@@ -46,7 +46,7 @@ export const {
       return plugins
     },
     FETCH_PLUGIN_HUB_STATS: () => async (dispatch, getState) => {
-      const version = getLatestRelease(getState())
+      const version = '1.6.30-SNAPSHOT'
       const response = await runeliteApi(`runelite-${version}/pluginhub`, {
         method: 'GET'
       })


### PR DESCRIPTION
Signed-off-by: Tomas Slusny <slusnucky@gmail.com>