### PR TITLE
Add plugin hub sorting based on updated and created time

### DIFF
--- a/src/modules/plugin-hub.js
+++ b/src/modules/plugin-hub.js
@@ -139,6 +139,10 @@ export const getSortedExternalPlugins = createSelector(
     switch (pluginSorting) {
       case 'active installs':
         return externalPlugins.sort((a, b) => b.count - a.count)
+      case 'time updated':
+        return externalPlugins.sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt)
+      case 'time added':
+        return externalPlugins.sort((a, b) => b.createdAt - a.createdAt)
       case 'name':
       default:
         return externalPlugins

--- a/src/routes/plugin-hub.js
+++ b/src/routes/plugin-hub.js
@@ -105,7 +105,12 @@ const PluginHub = ({
               <Choice
                 prefix="Sort by"
                 value={pluginSorting}
-                choices={['active installs', 'name']}
+                choices={[
+                  'active installs',
+                  'name',
+                  'time updated',
+                  'time added'
+                ]}
                 onClick={setPluginSorting}
               />
             </div>


### PR DESCRIPTION
Currently this is using temporary testing URL provided by abex. The url needs to be changed back before merging this.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>