### PR TITLE
Fix safari hover bug

### DIFF
--- a/src/components/tooltip.css
+++ b/src/components/tooltip.css
@@ -13,7 +13,6 @@
   left: 50%;
   margin-left: -100px !important;
   position: absolute;
-  z-index: 1000;
 }
 
 .tooltip-tag-text small {

--- a/src/routes/account.scss
+++ b/src/routes/account.scss
@@ -60,8 +60,10 @@
 }
 
 #account .card {
+  margin-top: 0;
   background: #171717;
   border: none;
+  transform: translateZ(0);
 }
 
 #account .card-header {
@@ -71,10 +73,6 @@
   border: none;
   border-bottom: 1px solid #232323;
   font-size: 14px;
-}
-
-#account .card {
-  margin-top: 0;
 }
 
 #account .card-title {

--- a/src/routes/account.scss
+++ b/src/routes/account.scss
@@ -64,6 +64,8 @@
   background: #171717;
   border: none;
   transform: translateZ(0);
+  position: relative;
+  z-index: 2;
 }
 
 #account .card-header {


### PR DESCRIPTION
This fixes https://github.com/runelite/runelite.net/issues/341

I'm not sure if this is a bug with safari but it looks like the culprit is `column-count` on `card-columns`. I'm also not sure if the safari engine caches styles when using `column-count` for performance reasons but it looks like if you enable gpu acceleration on the cards it'll solve this issue.
