### PR TITLE
Fix Instant parsing

### DIFF
--- a/src/modules/ge.js
+++ b/src/modules/ge.js
@@ -42,7 +42,7 @@ export const {
         const result = newEntries.map(entry => {
           entry.name = names[entry.itemId]
           entry.date = new Date(0)
-          entry.date.setUTCSeconds(entry.time.seconds)
+          entry.date.setUTCSeconds(Math.floor(entry.time / 1000))
           return entry
         })
 


### PR DESCRIPTION
As of commit 06b8e1b79881d6d6e171905d64c5f2891e2335cc, RuneLite encodes
`Instant`s as epoch millis. This commit updates references to fields of
that type to be read correctly.