### PR TITLE
Use map center for determining region name for tile markers & improve button/region headers

### DIFF
--- a/src/components/runescape-map.scss
+++ b/src/components/runescape-map.scss
@@ -10,3 +10,37 @@
   max-width: 300px;
   white-space: normal;
 }
+
+.leaflet-bar a {
+  background-color: #1e1e1e;
+  color: white;
+  border-bottom: none;
+}
+
+.leaflet-bar a:hover {
+  background-color: #1e1e1e;
+  color: #dc8a00;
+  cursor: pointer;
+  border-bottom: none;
+}
+
+.leaflet-bar a.leaflet-disabled {
+  cursor: default;
+  background-color: #222222;
+  color: #5a5a5a;
+}
+
+.leaflet-custom-control {
+  height: 30px;
+  line-height: 30px;
+  border-radius: 2px;
+  background-color: #1e1e1e;
+  color: white;
+  text-align: center;
+  display: block;
+  text-decoration: none;
+  padding-left: 6px;
+  padding-right: 6px;
+  font-size: 1.5em;
+  cursor: grab;
+}

--- a/src/routes/tile-show.js
+++ b/src/routes/tile-show.js
@@ -40,7 +40,6 @@ const mapTile = tile => {
     x,
     y,
     z,
-    region: regionId,
     label: tile['label'],
     color: jsColor
   }


### PR DESCRIPTION
- Use map center for determining region name for tile markers instead of
  relying on provided tiles
- Move region label to map instead of it being header above map
- Improve map button style to match rest of the site

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>