### PR TITLE
Add Share buttons to /account/tags and /account/tile-markers

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -125,3 +125,7 @@ video {
 .btn.disabled {
   cursor: default;
 }
+
+.user-select-none {
+  user-select: none !important;
+}

--- a/src/routes/account/tags.js
+++ b/src/routes/account/tags.js
@@ -28,7 +28,14 @@ const buildTag = tag => {
         <img alt="" src={formatIcon(tag.icon)} /> {tag.name}
       </h1>
 
-      <pre class="pre-select">{csv}</pre>
+      <pre class="pre-select">
+        {csv}
+        <div class="text-right">
+          <a href={'/tag/show/' + csv} class="user-select-none">
+            Share
+          </a>
+        </div>
+      </pre>
       <div class="row pl-2">
         {tag.items.map(item => {
           const name = item.name || ''

--- a/src/routes/account/tiles.js
+++ b/src/routes/account/tiles.js
@@ -37,7 +37,14 @@ const Tiles = ({ tiles, filter, setTileMarkersFilter }) => {
         />
       </div>
       <RuneScapeMap tiles={mapTiles} />
-      <pre class="pre-select">{mapData}</pre>
+      <pre class="pre-select">
+        {mapData}
+        <div class="text-right">
+          <a href={'/tile/show/#' + btoa(mapData)} class="user-select-none">
+            Share
+          </a>
+        </div>
+      </pre>
     </Fragment>
   )
 }


### PR DESCRIPTION
These buttons will navigate users to /tag/show and /tile/show with
selected data that is ready to be shared with others.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>