### PR TITLE
Add Loading component that is shown when data are loaded

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -83,7 +83,7 @@ const addSitePlugins = () => config => {
   }
 
   const posts = fs.readdirSync(path.join('src', '_posts'))
-  const routes = ['/', '/features', '/blog', '/tag', '/plugin-hub']
+  const routes = ['/', '/features', '/blog', '/tag', '/tile', '/plugin-hub']
     .map(path => ({ path }))
     .concat(
       posts.map(fileName => {

--- a/src/components/loading.js
+++ b/src/components/loading.js
@@ -1,0 +1,34 @@
+import { h } from 'preact'
+
+const Loading = () => (
+  <div
+    style={{
+      display: 'table',
+      width: '100%',
+      height: '100%'
+    }}
+  >
+    <div
+      style={{
+        display: 'table-cell',
+        verticalAlign: 'middle'
+      }}
+    >
+      <div
+        style={{
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          textAlign: 'center',
+          fontWeight: 700,
+          color: 'white'
+        }}
+      >
+        <div class="fa-4x">
+          <i class="fas fa-spinner fa-spin"></i>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+export default Loading

--- a/src/components/prepare.js
+++ b/src/components/prepare.js
@@ -1,13 +1,33 @@
 import { h, Component } from 'preact'
+import Loading from './loading'
 
 const prepare = prepareComponentData => WrappedComponent => {
   return class extends Component {
+    constructor() {
+      super()
+      this.state = {
+        loading: true
+      }
+    }
+
     componentDidMount() {
-      prepareComponentData(this.props)
+      const ret = prepareComponentData(this.props)
+      if (ret instanceof Promise) {
+        ret.then(() =>
+          this.setState({
+            loading: false
+          })
+        )
+      } else {
+        this.setState({
+          loading: false
+        })
+      }
     }
 
     render(props) {
-      return <WrappedComponent {...props} />
+      const { loading } = this.state
+      return loading ? <Loading /> : <WrappedComponent {...props} />
     }
   }
 }

--- a/src/components/runescape-map.js
+++ b/src/components/runescape-map.js
@@ -267,6 +267,10 @@ const prepareMap = map => {
   }
 
   planeButtons.addTo(map)
+
+  if (map.viewport) {
+    map.fitBounds(map.viewport)
+  }
 }
 
 const TileMapHandler = ({ tiles, selected, plane }) => {


### PR DESCRIPTION
Instead of showing target page directly, loading component will be shown
while data are being loaded. This also prevents displaying 404 page on
  first load of plugin pages etc.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>