### PR TITLE
Add nofollow to blog links

### DIFF
--- a/src/markdown-loader.js
+++ b/src/markdown-loader.js
@@ -31,6 +31,7 @@ module.exports = function (source) {
 
   parser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     tokens[idx].attrPush(['native', ''])
+    tokens[idx].attrPush(['rel', 'nofollow'])
     return defaultRender(tokens, idx, options, env, self)
   }
 


### PR DESCRIPTION
This stop google from attempting to crawl those links and then try to
crawl for example account page or pulse page.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>