### PR TITLE
Update /ghauth message to include `oauth_code:`

### DIFF
--- a/src/routes/gh-auth-code.js
+++ b/src/routes/gh-auth-code.js
@@ -12,8 +12,8 @@ const GitHubAuthCode = ({ code }) => (
         <h1 class="page-header">Almost there...</h1>
         <div>
           To complete authentication, send:
-          <pre class="pre-select">/ghauth {code}</pre>
-          In{' '}
+          <pre class="pre-select">/ghauth oauth_code:{code}</pre>
+          In the{' '}
           <a href="https://runelite.net/discord" title="RuneLite Discord">
             RuneLite Discord
           </a>


### PR DESCRIPTION
If a user copies the full command with token, Discord won't recognise it
as a slash command, causing the message to get posted to the channel.
This is not good. Turns out that to have it recognised with the token,
the arg name needs to be provided. Adding `oauth_code:` to the command
to copy results in Discord correctly identifying it as a slash command,
and it's filled out correctly.