### PR TITLE
Add net price tooltip to GE records

### DIFF
--- a/src/routes/account/grand-exchange.js
+++ b/src/routes/account/grand-exchange.js
@@ -1,6 +1,6 @@
 import { h, Fragment } from 'preact'
 import ago from 's-ago'
-import { numberWithCommas } from '../../util'
+import { numberWithCommas, determineTax } from '../../util'
 import { connect } from 'react-redux'
 import {
   fetchGe,
@@ -42,8 +42,11 @@ const buildRecord = record => (
         <p class="mb-0">
           <img src={`/img/ge_${record.buy ? 'bought' : 'sold'}.png`} alt="" />
           <span>{record.buy ? 'Bought' : 'Sold'}</span> for{' '}
-          <span>{numberWithCommas(record.price * record.quantity)}</span> gp (
-          <span>{numberWithCommas(record.price)}</span> gp/ea)
+          <span title={determineTax(record)}>
+            {' '}
+            {numberWithCommas(record.price * record.quantity)}
+          </span>{' '}
+          gp (<span>{numberWithCommas(record.price)}</span> gp/ea)
         </p>
       </div>
       <div class="ge-record-timestamp ml-auto">

--- a/src/util.js
+++ b/src/util.js
@@ -153,9 +153,10 @@ export const determineTax = item => {
 
   const tax = Math.floor(item.price * 0.01) * item.quantity
   const gross = item.price * item.quantity
-  const net = numberWithCommas(gross - tax)
+  const net = gross - tax
+  const netEach = Math.floor(net / item.quantity)
 
-  return `Net of ${net} gp = ${numberWithCommas(gross)} - ${numberWithCommas(
-    tax
-  )}`
+  return `Net of ${numberWithCommas(net)} gp = ${numberWithCommas(
+    gross
+  )} - ${numberWithCommas(tax)} (${numberWithCommas(netEach)} gp/ea)`
 }

--- a/src/util.js
+++ b/src/util.js
@@ -42,7 +42,7 @@ export const flattenMap = map => {
 export const toMMSS = s => {
   const minutes = Math.floor(s / 60)
   // Weird arithmetic is needed here to prevent rounding errors due to JS's floating point math
-  const seconds = Math.round(s % 60 * 10) / 10
+  const seconds = Math.round((s % 60) * 10) / 10
   const minutesStr = String(minutes).padStart(2, '0')
   const secondsStr = String(seconds).padStart(2, '0')
   return minutesStr + ':' + secondsStr
@@ -123,4 +123,39 @@ export const digest = (data, callback) => {
         callback(sha256)
       })
   }
+}
+
+export const determineTax = item => {
+  if (item.buy) return ''
+
+  const exemptMessage = 'Item is exempt from tax'
+
+  const exemptItems = [
+    1755, // chisel
+    5343, // dibber
+    5325, // gardening trowel
+    1785, // glassblowing pipe
+    2347, // hammer
+    1733, // needle
+    233, // pestle and mortar
+    5341, // rake
+    8794, // saw
+    5329, // secateurs
+    1735, // shears
+    952, // spade
+    5331 // watering can (0)
+  ]
+  const foundExemptItem = exemptItems.includes(item.itemId)
+  if (foundExemptItem) return exemptMessage
+
+  if (item.price < 100) return exemptMessage
+  if (item.price > 499999999) return numberWithCommas(5000000)
+
+  const tax = Math.floor(item.price * 0.01) * item.quantity
+  const gross = item.price * item.quantity
+  const net = numberWithCommas(gross - tax)
+
+  return `Net of ${net} gp = ${numberWithCommas(gross)} - ${numberWithCommas(
+    tax
+  )}`
 }


### PR DESCRIPTION
Closes #457

Adds a tool tip when hovering over the total amount on 'Sold' Grand Exchange records.

I am open to switching whether the net or gross is shown on the record without hovering. I do believe the net amount is more intuitive to see first. The native GE history itself shows the net amount more prominently.