### PR TITLE
Remove extra space between plugin hub sections and footer

### DIFF
--- a/src/routes/plugin-hub-show.js
+++ b/src/routes/plugin-hub-show.js
@@ -31,7 +31,7 @@ const PluginHubShow = ({ externalPlugin }) => {
       />
 
       <section id="externalPlugins">
-        <div class="content-section dark-card">
+        <div class="content-section dark-card pb-0">
           <div class="card">
             <div class="card-header card-body d-flex align-self-stretch">
               <div class="mr-4 d-flex align-items-center">

--- a/src/routes/plugin-hub.js
+++ b/src/routes/plugin-hub.js
@@ -62,7 +62,7 @@ const PluginHub = ({
       />
 
       <section id="externalPlugins">
-        <div class="content-section">
+        <div class="content-section pb-0">
           <h1 class="page-header">{author ? author + ' ' : ''}Plugin Hub</h1>
           <div class="row">
             <div class="col-sm-8">


### PR DESCRIPTION
| Before | After |
|:----------:|:-------:|
| ![Screenshot 2023-07-16 at 23-09-51 CoX Timers   Additions - Plugin Hub - RuneLite](https://github.com/runelite/runelite.net/assets/2199511/2f28b17e-90e3-4b7d-ab91-7d05295e71f6) | ![Screenshot 2023-07-16 at 23-10-10 CoX Timers   Additions - Plugin Hub - RuneLite](https://github.com/runelite/runelite.net/assets/2199511/6fce766f-0455-48f7-a6fa-24063ebb440a) |